### PR TITLE
Replace boilerplate README with project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ independently, evaluate each other anonymously, and a designated Chairman synthe
 the best final answer from all of that.
 
 This repository is the React UI. The backend is a separate Go service at
-[`llm-council-backend`](../llm-council-backend).
+[`llm-council-backend`](https://github.com/valpere/llm-council-backend).
 
 ---
 
@@ -50,7 +50,7 @@ Server-Sent Events.
 ## Prerequisites
 
 - Node.js 18+
-- The Go backend running on port 8001 (see [`llm-council-backend`](../llm-council-backend))
+- The Go backend running on port 8001 (see [`llm-council-backend`](https://github.com/valpere/llm-council-backend))
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaces the default Vite template README with a human-readable project README
- Explains what LLM Council does and how the 3-stage pipeline works
- Covers prerequisites, getting started, commands, project structure, and configuration
- Links to the detailed docs in `docs/`

## Test plan

- [ ] README renders correctly on GitHub
- [ ] All links to `docs/` files resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)