### PR TITLE
⚡ fix(stage3): show error banner when SSE stream emits error event

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -162,7 +162,13 @@ function App() {
             break;
 
           case 'error':
-            console.error('Stream error:', event.message);
+            setCurrentConversation((prev) => {
+              const messages = [...prev.messages];
+              const lastMsg = messages[messages.length - 1];
+              lastMsg.error = event.message;
+              lastMsg.loading.stage3 = false;
+              return { ...prev, messages };
+            });
             setIsLoading(false);
             break;
 

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -103,7 +103,9 @@ export default function ChatInterface({
                       <span>Running Stage 3: Final synthesis...</span>
                     </div>
                   )}
-                  {msg.stage3 && <Stage3 finalResponse={msg.stage3} />}
+                  {(msg.stage3 || msg.error) && (
+                    <Stage3 finalResponse={msg.stage3} error={msg.error} />
+                  )}
                 </div>
               )}
             </div>

--- a/src/components/Stage3.css
+++ b/src/components/Stage3.css
@@ -23,3 +23,28 @@
   line-height: 1.7;
   font-size: 15px;
 }
+
+.stage3-error {
+  background: #fff8f0;
+  border: 1px solid #f5c6a0;
+  border-radius: 6px;
+  padding: 16px;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.stage3-error-icon {
+  color: #b84800;
+  font-size: 16px;
+  flex-shrink: 0;
+  line-height: 1.4;
+}
+
+.stage3-error-message {
+  color: #b84800;
+  font-family: monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  word-break: break-word;
+}

--- a/src/components/Stage3.jsx
+++ b/src/components/Stage3.jsx
@@ -1,22 +1,29 @@
 import ReactMarkdown from 'react-markdown';
 import './Stage3.css';
 
-export default function Stage3({ finalResponse }) {
-  if (!finalResponse) {
+export default function Stage3({ finalResponse, error }) {
+  if (!finalResponse && !error) {
     return null;
   }
 
   return (
     <div className="stage stage3">
       <h3 className="stage-title">Stage 3: Final Council Answer</h3>
-      <div className="final-response">
-        <div className="chairman-label">
-          Chairman: {finalResponse.model.split('/')[1] || finalResponse.model}
+      {error ? (
+        <div className="stage3-error">
+          <span className="stage3-error-icon">⚠</span>
+          <span className="stage3-error-message">{error}</span>
         </div>
-        <div className="final-text markdown-content">
-          <ReactMarkdown>{finalResponse.response}</ReactMarkdown>
+      ) : (
+        <div className="final-response">
+          <div className="chairman-label">
+            Chairman: {finalResponse.model.split('/')[1] || finalResponse.model}
+          </div>
+          <div className="final-text markdown-content">
+            <ReactMarkdown>{finalResponse.response}</ReactMarkdown>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Set `msg.error` and clear `loading.stage3` on SSE `error` event
- Render Stage3 panel when either `finalResponse` or `error` is set
- Add amber error banner displaying the verbatim error message
- Fixes spinner hanging forever when error arrives after `stage3_start`

Closes #9

## Test plan
- [ ] Dev server starts (`npm run dev`)
- [ ] Successful Stage3 completion unchanged
- [ ] Error state: trigger with invalid API key/model — amber banner appears, spinner stops
- [ ] Loaded conversation (no `error` field) renders unchanged
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)