### PR TITLE
⚡ docs(api): add Adapter pattern JSDoc to api.js

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -2,10 +2,11 @@
  * API client for the LLM Council backend.
  *
  * Adapter pattern: this module is the sole point of contact between the React
- * frontend and the Go backend.  All fetch calls and SSE stream parsing live
- * here.  Components and App.jsx never import fetch or talk to the backend
- * directly — they only call methods on this `api` object and receive plain JS
- * values or invoke the `onEvent(eventType, event)` callback.
+ * frontend and the Go backend.  All network requests (`fetch` calls) and SSE
+ * stream parsing live here.  Components and App.jsx never call `fetch` or
+ * perform network requests directly — they only call methods on this `api`
+ * object and receive plain JS values, or provide an `onEvent(eventType, event)`
+ * callback that `sendMessageStream` calls.
  *
  * SSE boundary: `sendMessageStream` reads the raw ReadableStream and fires
  * `onEvent` once per parsed SSE data line.  App.jsx owns all state mutations


### PR DESCRIPTION
## Summary
- Documents the Adapter role of `src/api.js` as the sole fetch/SSE boundary between the React frontend and Go backend
- Clarifies that components never call `fetch` directly — all API access flows through this module
- Explains the stateless SSE boundary and `onEvent(eventType, event)` callback contract

Closes #13

## Test plan
- [ ] Dev server starts (`npm run dev`)
- [ ] No console errors
- [ ] JSDoc visible in `src/api.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)