### PR TITLE
⚡ chore(dx): rename /plan skill to /backlog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ done
 ```
 
 This registers all project skills in `.claude/skills/` as slash commands in Claude Code.
+Note: `.claude/` is excluded from git by the global gitignore (`.*`), so skill files live only on the local filesystem and must be set up per machine using the snippet above.
 
 There is no test suite.
 


### PR DESCRIPTION
## Summary
- Renames `.claude/skills/plan/` → `.claude/skills/backlog/` to avoid collision with Claude Code's built-in `/plan` command (Plan Mode), which was showing two `/plan` entries in the skills menu
- Updates `CLAUDE.md` to reference `/backlog`
- Notified backend sibling via onlooking protocol to do the same

## Test plan
- [ ] Dev server starts (`npm run dev`)
- [ ] `/backlog` appears once in the skills menu (no duplicate `/plan`)
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)