### PR TITLE
⚡ chore(dx): remove onlooking protocol

### DIFF
--- a/.claude/agents/backend-sync.md
+++ b/.claude/agents/backend-sync.md
@@ -1,13 +1,13 @@
 ---
 name: backend-sync
-description: Checks the llm-council-backend repo for SSE contract changes, new/closed issues, and merged PRs relevant to the frontend. Appends a timestamped note to the onlooking outbox for the backend Claude instance. Reads any pending inbound note and acts on it. Run hourly by cron (re-created on SessionStart).
+description: Checks the llm-council-backend repo for SSE contract changes, new/closed issues, and merged PRs relevant to the frontend. Run hourly by cron (re-created on SessionStart).
 tools: Read, Glob, Grep, Bash
 model: haiku  # lightweight read-only sync; no code generation — haiku is sufficient and fast
 type: agents
 metadata:
-  version: "1.1"
+  version: "1.2"
   author: frontend-claude
-  last_updated: "2026-03-22"
+  last_updated: "2026-03-29"
 ---
 
 # Backend Sync Agent
@@ -15,16 +15,13 @@ metadata:
 ## Purpose
 
 Keep the frontend in sync with backend changes that affect the SSE wire format, REST
-API contract, or coordination agreements. Exchange notes with the sibling backend Claude
-instance via the onlooking protocol.
+API contract, or open issues.
 
 ## Inputs / tools used
 
 - `Read` — backend repo files (docs/, main Go source)
 - `Glob` / `Grep` — detect changes in SSE event types, API endpoints
 - `Bash(git log:*)` — check recent commits in `../llm-council-backend`
-- `Bash(flock:*)` — atomic read-then-truncate of inbound onlooking file
-- `Bash(cat >>:*)` or `Bash(tee -a:*)` — append to outbound onlooking file
 
 ## What to check
 
@@ -34,32 +31,10 @@ instance via the onlooking protocol.
 3. **Issue #19** — CORS origins configurable; notify immediately if merged so
    `VITE_API_BASE` can land simultaneously
 4. **Any new GitHub issues** tagged as frontend-relevant
-5. **Inbound onlooking note** — read and act on any message from backend Claude
-
-## Onlooking protocol
-
-**Inbound (read + truncate):**
-```bash
-flock -x -w 10 .claude/.onlooking-from-backend.md.lock \
-  bash -c 'cat .claude/.onlooking-from-backend.md; truncate -s 0 .claude/.onlooking-from-backend.md'
-```
-
-**Outbound (append only — never overwrite):**
-```bash
-cat >> ../llm-council-backend/.claude/.onlooking-from-frontend.md << 'EOF'
-
-## [YYYY-MM-DD HH:MM] Frontend sync — <topic>
-
-<note content>
-EOF
-```
 
 ## Output format
 
-Append a block to `../llm-council-backend/.claude/.onlooking-from-frontend.md` only if
-there is something worth communicating. Silence is fine when nothing changed.
-
-Include: timestamp, topic heading, concise finding, and any action requested of the backend.
+Report findings directly in the conversation. Silence is fine when nothing changed.
 
 ## Confidence language
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,6 @@ dist-ssr
 !.claude/skills/
 !.claude/skills/**
 # Keep ephemeral/local files excluded:
-.claude/.onlooking-from-backend.md
-.claude/.onlooking-from-backend.md.lock
 .claude/settings.local.json
 
 # Editor directories and files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ refactor/{description}        e.g. refactor/extract-sse-handler
 
 **Agents** (invoked via `Agent` tool):
 - `tech-lead` — architectural authority; reviews plans before implementation and code before merging; enforces SSE adapter boundary, App.jsx state model, and security rules
-- `backend-sync` — runs hourly (cron re-created on SessionStart); checks backend git log, SSE contract; exchanges notes via onlooking protocol
+- `backend-sync` — runs hourly (cron re-created on SessionStart); checks backend git log, SSE contract, and new issues for frontend-relevant changes
 - `bug-fixer` — surgical one-bug fix; one bug, one minimal fix, one commit
 - `code-simplifier` — behaviour-preserving JS refactor; no TypeScript, no test suite
 - `docs-maintainer` — post-merge doc sync for CLAUDE.md, docs/, and .proposals.md
@@ -100,10 +100,6 @@ refactor/{description}        e.g. refactor/extract-sse-handler
 All agents have persistent memory in `.claude/agent-memory/<agent-name>/`.
 
 **Proposals:** open `.proposals.md` at repo root for pending ideas and design decisions.
-
-**Onlooking protocol:**
-- Outbox (sole writer): `../llm-council-backend/.claude/.onlooking-from-frontend.md` — always **append**, never overwrite
-- Inbox: `.claude/.onlooking-from-backend.md` — read with flock, truncate after processing
 
 ## Known gaps
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -164,7 +164,7 @@ Only modifies `.github/workflows/`. Uses `npm ci`, Node 20, concurrency cancella
 
 **When invoked:** hourly by cron (re-created on `SessionStart`).
 
-Checks `../llm-council-backend` for SSE contract changes, new REST endpoints, and new issues. Exchanges notes with the backend Claude instance via the onlooking protocol (append-only outbox file).
+Checks `../llm-council-backend` for SSE contract changes, new REST endpoints, and new issues relevant to the frontend.
 
 ---
 
@@ -332,24 +332,6 @@ All agents maintain persistent memory in `.claude/agent-memory/<agent-name>/`. M
 Memory files use frontmatter (`name`, `description`, `type`) and are indexed in `MEMORY.md` inside each agent's directory.
 
 **Not saved:** code patterns, architecture, file paths (derivable from the code), git history (use `git log`), anything in `CLAUDE.md`, or ephemeral task state.
-
----
-
-## Onlooking Protocol (Backend ↔ Frontend)
-
-The frontend and backend each have a sibling Claude instance. They exchange notes via append-only files:
-
-| Direction | File | Writer | Reader |
-|-----------|------|--------|--------|
-| Frontend → Backend | `../llm-council-backend/.claude/.onlooking-from-frontend.md` | `backend-sync` agent | Backend Claude |
-| Backend → Frontend | `.claude/.onlooking-from-backend.md` | Backend Claude | `backend-sync` agent |
-
-**Rules:**
-- The outbox is **append-only** — never overwrite; the receiver truncates after reading
-- Use timestamped headings: `## [YYYY-MM-DD HH:MM] Frontend sync — <topic>`
-- Silence is fine when nothing changed
-
-The `backend-sync` agent runs hourly (re-created on `SessionStart`). It checks the backend git log for SSE contract changes and REST endpoint modifications, then sends a note if anything is relevant.
 
 ---
 


### PR DESCRIPTION
## Summary

- Removes the file-based frontend↔backend coordination mechanism (`.onlooking-from-backend.md` and lock file)
- Updates `CLAUDE.md`, `docs/development-workflow.md`, and `.claude/agents/backend-sync.md` to remove all references
- Removes `.gitignore` exclusions for the now-deleted files
- Deletes the local onlooking files

The `backend-sync` agent is retained but simplified — it now reports findings directly in the conversation rather than writing to a shared file.

## Test plan

- [ ] `CLAUDE.md` no longer mentions onlooking protocol
- [ ] `docs/development-workflow.md` no longer has the "Onlooking Protocol" section
- [ ] `backend-sync.md` no longer references flock/append commands
- [ ] `.gitignore` no longer excludes `.onlooking-*` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)