### PR TITLE
chore(dx): add dreaming/session-recall tooling, rewrite fix-review and ship skills

### DIFF
--- a/.claude/agents/bug-fixer.md
+++ b/.claude/agents/bug-fixer.md
@@ -55,7 +55,7 @@ If a bug points to these patterns, the root cause is elsewhere:
 
 - **State in App.jsx only:** all assistant message state lives in `App.jsx`; components receive it via props
 - **api.js is the only HTTP/SSE client:** never add `fetch` or `EventSource` calls in components
-- **No test suite:** verify by running the dev server and reproducing the issue manually
+- **Verify with `npm test` (Vitest) where a relevant test exists; otherwise reproduce the issue manually** via the dev server
 - **SSE error events:** `{"type":"error","message":"..."}` is a terminal event — stream ends after it
 
 ## Verification

--- a/.claude/agents/ci-build-agent.md
+++ b/.claude/agents/ci-build-agent.md
@@ -6,7 +6,7 @@ model: sonnet
 color: lime
 ---
 
-You are the CI / Build Agent for the **LLM Council frontend** — a specialist in GitHub Actions workflow creation, validation, and maintenance. Your sole responsibility is ensuring the CI/CD pipeline is reliable, fast, and correctly configured.
+You are the CI / Build Agent for the **VMM Rada frontend** — a specialist in GitHub Actions workflow creation, validation, and maintenance. Your sole responsibility is ensuring the CI/CD pipeline is reliable, fast, and correctly configured.
 
 ## Boundaries
 
@@ -33,10 +33,9 @@ When you encounter failures outside your scope, diagnose and escalate — never 
 ```
 npm ci
 npm run lint
+npm test
 npm run build
 ```
-
-**No test suite** — do not add a `npm run test` step.
 
 **Optional env var at build time:**
 - `VITE_API_BASE` — backend URL (defaults to `http://localhost:8001`; only needed if deploying to a non-local environment)
@@ -100,7 +99,7 @@ jobs:
 5. **NEVER hardcode secret values** — always use `${{ secrets.* }}`
 6. **Production gate**: always use `environment: production` for prod deploys
 7. **No `npm install`** in CI — always `npm ci`
-8. **No test step** — this project has no test suite
+8. **Include `npm test`** (Vitest) between lint and build
 
 ---
 
@@ -132,7 +131,7 @@ jobs:
 - [ ] No hardcoded secret values
 - [ ] All secrets use `${{ secrets.* }}` syntax
 - [ ] Concurrency cancellation block is present
-- [ ] No `npm run test` step (no test suite)
+- [ ] `npm test` step is present (between lint and build)
 - [ ] No files outside `.github/workflows/` were modified
 
 ---

--- a/.claude/agents/code-generator.md
+++ b/.claude/agents/code-generator.md
@@ -6,7 +6,7 @@ model: sonnet
 color: yellow
 ---
 
-You are the Code Generator for the **LLM Council frontend** — a React 19 + Vite 8 SPA in plain JavaScript. You implement GitHub issues with precision, following every established pattern. You operate after the Tech Lead has approved the approach and before PR creation.
+You are the Code Generator for the **VMM Rada frontend** — a React 19 + Vite 8 SPA in plain JavaScript. You implement GitHub issues with precision, following every established pattern. You operate after the Tech Lead has approved the approach and before PR creation.
 
 ## Your Role in the Pipeline
 
@@ -20,7 +20,7 @@ Code Generator (YOU)  — implement
   ↓
 code-simplifier  — readability pass
   ↓
-/ship            — PR, Copilot, merge
+/ship            — PR, /fix-review, merge
 ```
 
 Never skip the parallel review step. Always launch security-reviewer and static-analysis simultaneously in a single Agent tool call batch.
@@ -32,7 +32,7 @@ Never skip the parallel review step. Always launch security-reviewer and static-
 - React 19 + Vite 8, **plain JavaScript** (no TypeScript)
 - ESLint 10 with flat config (`eslint.config.js`)
 - `react-markdown` for LLM output rendering
-- No test suite, no Redux, no Context API, no Supabase
+- No Redux, no Context API, no Supabase. Tests: Vitest + Testing Library.
 
 ## Architecture Rules (MUST follow)
 

--- a/.claude/agents/pm-issue-writer.md
+++ b/.claude/agents/pm-issue-writer.md
@@ -6,7 +6,7 @@ model: sonnet
 color: pink
 ---
 
-You are the **PM Agent for the LLM Council frontend** — a requirements formalisation specialist. Your sole responsibility is translating informal requests into precise, implementation-ready GitHub issue drafts.
+You are the **PM Agent for the VMM Rada frontend** — a requirements formalisation specialist. Your sole responsibility is translating informal requests into precise, implementation-ready GitHub issue drafts.
 
 You **do not write code, design architecture, or make implementation decisions**. You produce specification only.
 
@@ -56,7 +56,7 @@ Architecture constraints to check before writing requirements:
 - State mutations MUST go through `App.jsx` via `setCurrentConversation`
 - Components MUST NOT call `src/api.js` or `fetch` directly
 - `metadata.label_to_model` is ephemeral — not persisted
-- No TypeScript, no test suite, no Redux, no Context API
+- No TypeScript, no Redux, no Context API. Tests: Vitest + Testing Library.
 
 ---
 

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -6,7 +6,7 @@ model: sonnet
 color: blue
 ---
 
-You are an application security engineer auditing the **LLM Council frontend** — a React 19 + Vite 8 single-page app in plain JavaScript (no TypeScript). You review recently written or modified code for security vulnerabilities. You **report only** — never modify code.
+You are an application security engineer auditing the **VMM Rada frontend** — a React 19 + Vite 8 single-page app in plain JavaScript (no TypeScript). You review recently written or modified code for security vulnerabilities. You **report only** — never modify code.
 
 ## Stack Context
 

--- a/.claude/agents/static-analysis.md
+++ b/.claude/agents/static-analysis.md
@@ -6,7 +6,7 @@ model: sonnet
 color: white
 ---
 
-You are the Static Analysis Agent for the **LLM Council frontend**. Your sole purpose is to ensure `npm run lint` passes **without changing any runtime behaviour**.
+You are the Static Analysis Agent for the **VMM Rada frontend**. Your sole purpose is to ensure `npm run lint` passes **without changing any runtime behaviour**.
 
 ## Core Mandate
 

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -6,7 +6,7 @@ model: opus
 color: green
 ---
 
-You are the Tech Lead of the **LLM Council frontend** — a React 19 + Vite 7 single-page application that presents a 3-stage LLM deliberation pipeline as a chat interface. The stack is plain JavaScript (no TypeScript), no Redux, no Context API, no test suite. ESLint is the only automated quality gate.
+You are the Tech Lead of the **VMM Rada frontend** — a React 19 + Vite 8 single-page application that presents a 3-stage LLM deliberation pipeline as a chat interface. The stack is plain JavaScript (no TypeScript), no Redux, no Context API. Automated quality gates: ESLint (`npm run lint`) and Vitest (`npm test`).
 
 You are the **technical authority** for this codebase. You review, guide, and enforce architecture. You do not implement large features yourself. You reject code that violates the architecture and explain precisely why and how to fix it.
 

--- a/.claude/context-essentials.md
+++ b/.claude/context-essentials.md
@@ -1,0 +1,61 @@
+# Context Essentials — vmm-rada-web-ui
+
+> Re-injected into session context after compaction (via SessionStart hook
+> with matcher='compact') and emphasized to the compactor (via PreCompact
+> hook). Source of truth for rules that MUST survive context summarization.
+>
+> Keep this file under ~60 lines — every line costs tokens on each
+> re-injection.
+
+## Architecture (immutable)
+
+These four rules are **load-bearing**. Violations break the architecture
+contract and require Tech Lead override.
+
+1. **Components are pure UI.** No `fetch` or `api.js` calls from any component.
+2. **`src/api.js` is the adapter boundary.** `onEvent(type, event)` is the only
+   interface `App.jsx` sees. Raw SSE lines and HTTP status codes never leak.
+3. **`App.jsx` owns all state.** Only `App.jsx` writes the assistant message
+   shape via `setCurrentConversation`.
+4. **`react-markdown` is the only renderer for LLM output.** Inserting raw
+   HTML is forbidden — XSS risk with LLM-generated content.
+
+## Stack constraints
+
+- React 19 + Vite 8, plain JavaScript. No TypeScript, no Redux, no Context API.
+- Tests: Vitest + Testing Library (`npm test`).
+- Backend: [`vmm-rada`](https://github.com/valpere/vmm-rada) (Go), separate
+  repo. Must be running locally (port 8001) for dev/testing against real data.
+
+## Workflow gates
+
+```
+/backlog → Tech Lead (APPROVED) → gh issue create → plan file deleted
+    → /ship → code-generator → [/fix-review rounds] → squash merge
+```
+
+- **Plans** live in `.claude/plans/` with frontmatter (type, priority, labels,
+  github_issue). After issue creation, delete the plan file.
+- **Tech Lead approval** is the gate before any code generation.
+- **PRs** are squash-merged. Never merge commits or rebase-merge.
+- **`/fix-review`** runs parallel multi-model review (Ollama, see `config.yaml`)
+  + Claude arbiter. **Not** Copilot-based — Copilot was dropped from the org
+  workflow 2026-05-13; never wait for it.
+
+## Docs discipline
+
+- **Mark planned vs current explicitly.** When a doc describes a feature
+  not yet wired into code, prefix the section with `PLANNED:` or
+  `NOT YET WIRED:`. Never write future-tense behaviour as if it were
+  current.
+- **Update `CLAUDE.md` and `docs/*.md` together** when a feature lands.
+  Drift between these is a common review comment.
+
+## Banned patterns
+
+- No `--no-verify` on git operations.
+- No direct `fetch` in components — must go through `src/api.js`.
+- No raw HTML rendering of LLM output — `react-markdown` only.
+- No state writes outside `App.jsx`.
+- No TypeScript.
+- No commits skipping pre-commit hooks unless user explicitly requests.

--- a/.claude/dreaming/README.md
+++ b/.claude/dreaming/README.md
@@ -1,0 +1,125 @@
+# Dreaming — vmm-rada-web-ui project
+
+Project-specific dreaming pass. Виявляє drift від `context-essentials.md`,
+recurring `/fix-review` теми, stale plans, agent-memory health.
+
+## Запуск
+
+Manually:
+```bash
+~/wrk/projects/vmm-rada-web-ui/vmm-rada-web-ui/.claude/dreaming/dreaming.sh
+```
+
+Scheduled — **systemd user timer** (recommended, catches up missed runs).
+Create **two** unit files at the paths shown below:
+
+`~/.config/systemd/user/dreaming-vmm-rada-web-ui.service`:
+
+```ini
+[Service]
+Type=oneshot
+ExecStart=/home/val/wrk/projects/vmm-rada-web-ui/vmm-rada-web-ui/.claude/dreaming/dreaming.sh
+# `claude` CLI needs AI_PROVIDER_API_KEY (and any other secrets the script
+# uses). systemd user units start with a near-empty environment, so the
+# script's reliance on a parent shell loading .env doesn't apply here —
+# load it explicitly. EnvironmentFile= treats the file as missing-OK only
+# when prefixed with `-`, which is what we want during first-run setup.
+EnvironmentFile=-%h/wrk/projects/vmm-rada-web-ui/vmm-rada-web-ui/.env
+# Use the script's own log directory (~/.cache/vmm-rada-web-ui/, mode 0700)
+# rather than /tmp — /tmp is world-readable and could leak secrets if the
+# pass ever logs prompt content, env values, or stack traces.
+StandardOutput=append:%h/.cache/vmm-rada-web-ui/dreaming-systemd.log
+StandardError=append:%h/.cache/vmm-rada-web-ui/dreaming-systemd.log
+```
+
+`~/.config/systemd/user/dreaming-vmm-rada-web-ui.timer`:
+
+```ini
+[Unit]
+Description=Weekly vmm-rada-web-ui dreaming pass
+
+[Timer]
+# Clear of other Sunday dreaming passes: user-level 03:00, vmm-rada
+# backend 04:00, llm-wiki 05:00, lance-agent 06:00, growthcore 06:30,
+# depl-orch 07:00. Nominal — комп зазвичай вимкнений.
+OnCalendar=Sun 05:30
+# Catch up the most recent missed run at next login.
+Persistent=true
+# Spread bursty boot-time catchups.
+RandomizedDelaySec=5min
+
+[Install]
+WantedBy=timers.target
+```
+
+Activate:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now dreaming-vmm-rada-web-ui.timer
+
+# Optional but recommended: keeps the user-level systemd manager running
+# even when you're logged out, so the timer fires on overnight catchup
+# instead of waiting for your next login session. Likely already enabled
+# if vmm-rada backend's own dreaming timer is active — check first with
+# `loginctl show-user "$USER" | grep Linger` before re-running.
+loginctl enable-linger "$USER"
+```
+
+**Чому НЕ cron:** vanilla cron не догоняє пропущених runs — якщо комп
+вимкнений у Sun 06:00, run просто втрачається. systemd `Persistent=true`
+запам'ятовує **останній** пропущений елапс і фаєриться на наступному
+login (multi-week downtime ≠ multiple backfilled runs — one catch-up only,
+plus the next normal cadence). `anacron` would also catch up but it lacks
+per-minute granularity and rarely covers user crontabs.
+
+## Що шукає
+
+1. **Context-essentials drift** — порушення immutable rules у recent commits
+   - Грепає `--no-verify`, raw HTML, state writes outside App.jsx, etc.
+2. **Recurring `/fix-review` themes** — читає PR-коментарі за останні 15 PR
+   - Якщо одна тема повторюється у 3+ PR → кандидат на нове правило
+3. **Stale plans** — `.claude/plans/*.md` старші 14 днів
+4. **Agent-memory health** — застарілі / дублюючі / суперечливі memory
+5. **Skill / agent inventory** — невикористані skills, overlapping responsibilities
+6. **Backend contract drift** — чи не відстали `docs/api-contract.md` /
+   `docs/streaming.md` від реального Go backend (окремий репозиторій, не
+   в CI цього проєкту — зона реального ризику для frontend-only репо)
+
+## Звіти
+
+Зберігаються в `reports/YYYY-W##.md`. Track-аються в git як audit trail.
+
+`reports/.dreaming.log` — журнал запусків (gitignored).
+
+## Workflow читання
+
+Понеділок ранок:
+1. `cat .claude/dreaming/reports/$(date +%Y-W%V).md`
+2. Для high-confidence drift items — створити issue або одразу fix
+3. Для recurring fix-review themes — додати рядок у `context-essentials.md` або обговорити з командою
+4. Для stale plans — або підняти, або `git rm`
+
+## Чим відрізняється від /revival
+
+| | /revival | dreaming |
+|---|----------|----------|
+| Тригер | On-demand | Scheduled (systemd timer) |
+| Scope | Health snapshot | Pattern detection across time |
+| Вхід | Структура зараз | Recent commits + PR comments |
+| Output | Snapshot діагноз | Trend report |
+
+Доповнюють одне одне. /revival — "як я зараз?", dreaming — "що в мене
+накопичилось?"
+
+## Cost
+
+~$0.5-1 per pass (Opus, ~30-60K input tokens, ~5-10K output).
+Тижневий запуск → ~$2-4/місяць. Щоденний — ~$15-30/місяць (overkill).
+
+## Related
+
+- Backend's own dreaming: `~/wrk/projects/vmm-rada/vmm-rada/.claude/dreaming/`
+  (Sunday 04:00 — offset from this one to avoid API-load collision)
+- User-level: `~/wrk/common/dreaming/` (cross-project Claude Code memory)
+- Wiki: `~/Documents/llm-wiki/wiki/dreaming.md` (загальний concept)

--- a/.claude/dreaming/dreaming-prompt.md
+++ b/.claude/dreaming/dreaming-prompt.md
@@ -1,0 +1,154 @@
+You are doing a **dreaming pass** for the **vmm-rada-web-ui** project —
+async, scheduled curation of project context. This is sleep-time
+consolidation: review what accumulated since last pass, identify
+patterns, suggest curation.
+
+## Project context
+
+- **vmm-rada-web-ui** — React 19 + Vite 8 frontend for VMM Rada, a
+  multi-LLM deliberation system. Backend is a separate repo
+  ([`vmm-rada`](https://github.com/valpere/vmm-rada), Go).
+- Workflow: `/backlog → Tech Lead → /ship → /fix-review (multi-model, Ollama) → squash merge`
+- Source of truth: `CLAUDE.md` (project instructions)
+- See `.claude/context-essentials.md` for immutable rules
+
+## Targets
+
+| Path | What to look for |
+|------|------------------|
+| `.claude/context-essentials.md` | Are these rules still followed? Find recent commits that may violate them |
+| `.claude/agent-memory/MEMORY.md` + per-agent dirs (if present) | Stale memories, outdated agent learnings |
+| `.claude/plans/` | Plans that lingered too long, never made it to a PR |
+| `.claude/agents/` | Agents with overlapping responsibilities |
+| `.claude/skills/` | Skills that may be obsolete or duplicated |
+| `git log --since="3 months ago"` | Recurring failure patterns, oft-reverted commits |
+| Recent PR comments | Recurring `/fix-review` themes (security, simplifier, tech-lead) |
+
+## What to find
+
+### 1. Drift from context-essentials.md
+
+For each rule in `.claude/context-essentials.md`, search recent commits
+(last 30 days) for potential violations. Examples:
+- "No `--no-verify`" → grep git log for `--no-verify`
+- "No raw HTML rendering of LLM output" → grep `src/` for the
+  React-internal raw-HTML escape hatch (the `dangerouslySet...`
+  attribute name) and any direct `innerHTML` writes
+- "App.jsx owns all state" → grep `src/components/` for `setCurrent`
+- "No direct fetch in components" → grep `src/components/` for `fetch(`
+- "`react-markdown` is the only renderer" → grep for competing
+  markdown/HTML renderers introduced by mistake
+
+Flag violations with confidence level.
+
+### 2. Recurring `/fix-review` themes
+
+Read recent PR review comments via `gh pr list --state merged --limit 20`
+and `gh pr view N --json comments`. Identify themes that come up multiple
+times across PRs (e.g. "missing null check on SSE event payload" appears
+in 4 PRs). These are candidates for:
+- New rule in `context-essentials.md`
+- New skill or agent specialization
+- Pattern documented in an agent's `MEMORY.md`
+
+### 3. Stale plans
+
+Plans in `.claude/plans/` should be deleted after issue creation per
+CLAUDE.md. Find any plans older than 14 days — they're either stuck
+or forgotten.
+
+### 4. Agent-memory health
+
+If any agent has its own `MEMORY.md` folder, check:
+- Memories that contradict context-essentials
+- Memories not used in any recent session (mtime > 60 days)
+- Duplicate memories across agents (suggest deduplicating to top-level)
+
+### 5. Skill obsolescence
+
+`.claude/skills/` may contain skills that were tried but now unused.
+Cross-reference with recent slash-command usage in transcripts.
+
+### 6. Backend contract drift
+
+The frontend depends on the Go backend's API/SSE contract
+(`docs/api-contract.md`, `docs/streaming.md`). If the backend repo has
+made contract-relevant changes since the docs were last updated (check
+`docs/*.md` mtimes vs. recent conversation history for backend-sync
+notes), flag it — this frontend can drift silently from a backend it
+doesn't build against in CI.
+
+## Method
+
+1. **Read** `.claude/context-essentials.md` first — it's the contract
+2. **Sample** recent commits: `git log --oneline --since="30 days ago" | head -30`
+3. **Sample** recent PRs: `gh pr list --state merged --limit 15 --json number,title,comments`
+4. **Read** agent MEMORY.md files if present (selectively — one per agent)
+5. **Inventory** plans, skills, agents
+6. **Cross-compare** for patterns
+7. **Output a report**
+
+## Constraints (CRITICAL)
+
+- **Read-only.** Do NOT modify any files.
+- **No `git commit`, `gh pr edit`, `Edit`, `Write` calls.**
+- **Allowed**: `Read`, `Glob`, `Grep`, `Bash` (read-only commands like `git log`, `gh pr view`, `ls`, `cat`, `wc`).
+- **Cite sources** — every claim references a path or commit-SHA.
+- **Confidence levels** — `high`/`medium`/`low`.
+
+## Report format
+
+```markdown
+# vmm-rada-web-ui dreaming pass — YYYY-W##
+
+Date: YYYY-MM-DD
+Branch surveyed: <current branch>
+Commits examined: <count> (since <date>)
+PRs examined: <count>
+
+## TL;DR
+- <2-4 highest-impact actionable items>
+
+## 1. Context-essentials drift
+- <rule>
+  - Evidence: commit SHA / file:line
+  - Severity: high/medium/low
+  - Suggest: ...
+
+## 2. Recurring /fix-review themes
+- "<theme>" — n=<count> in PRs [#X, #Y, #Z]
+  - Suggest: add to context-essentials? new skill?
+  - Confidence: ...
+
+## 3. Stale plans
+- <plan-file> — age: <days>, status: ...
+  - Suggest: ship / delete / revive
+
+## 4. Agent-memory health
+- <agent>:
+  - Stale memories: N (oldest mtime)
+  - Contradictions with context-essentials: ...
+  - Duplicates with other agents: ...
+
+## 5. Skill / agent inventory
+- Unused skills: ...
+- Overlapping agent roles: ...
+
+## 6. Backend contract drift
+- ...
+
+## 7. Patterns I noticed
+- ...
+
+## 8. What I couldn't tell (need manual review)
+- ...
+```
+
+## Output formatting
+
+- Output the report as **plain markdown**.
+- Do **NOT** wrap the entire report in a ` ```markdown ` code fence.
+- Do **NOT** add preamble like "I have enough sample data..." — start
+  directly with the `# vmm-rada-web-ui dreaming pass — ...` heading.
+- Do **NOT** add postamble like "Report complete." — end after the
+  last section.

--- a/.claude/dreaming/dreaming.sh
+++ b/.claude/dreaming/dreaming.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# vmm-rada-web-ui project dreaming pass.
+#
+# Purpose: scheduled (weekly) curation of .claude/context-essentials.md drift,
+# /fix-review themes, stale plans, agent-memory health.
+# Read-only — outputs report only.
+#
+# Schedule (cron): `30 5 * * 0  /home/val/wrk/projects/vmm-rada-web-ui/vmm-rada-web-ui/.claude/dreaming/dreaming.sh`
+# (Sunday 05:30 — clear of the other Sunday dreaming passes: user-level
+# 03:00, vmm-rada backend 04:00, llm-wiki 05:00, lance-agent 06:00,
+# growthcore 06:30, depl-orch 07:00. Check `systemctl --user list-timers
+# 'dreaming-*'` for the live schedule before picking a slot for a new project.)
+
+set -euo pipefail
+
+# Ensure claude/gh/jq are reachable when invoked from cron or other minimal env
+export PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPORTS_DIR="$SCRIPT_DIR/reports"
+PROMPT_FILE="$SCRIPT_DIR/dreaming-prompt.md"
+WEEK="$(date +%Y-W%V)"
+REPORT="$REPORTS_DIR/$WEEK.md"
+LOG="$REPORTS_DIR/.dreaming.log"
+
+mkdir -p "$REPORTS_DIR"
+
+if [[ ! -f "$PROMPT_FILE" ]]; then
+  echo "[dreaming] missing prompt file: $PROMPT_FILE" >&2
+  exit 1
+fi
+
+if [[ ! -d "$PROJECT_DIR/.git" ]]; then
+  echo "[dreaming] not a git repo: $PROJECT_DIR" >&2
+  exit 1
+fi
+
+echo "[$(date -Iseconds)] vmm-rada-web-ui dreaming pass started" >> "$LOG"
+
+# Run from project root so relative paths in prompt work.
+cd "$PROJECT_DIR"
+
+PROMPT="$(cat "$PROMPT_FILE")
+Today is $(date -I).
+Current branch: $(git rev-parse --abbrev-ref HEAD).
+Project root: $PROJECT_DIR.
+Write the report to stdout."
+
+# Prompt via stdin — `--allowed-tools <tools...>` is variadic and would
+# otherwise consume the positional prompt argument.
+echo "$PROMPT" | claude \
+  --print \
+  --model opus \
+  --allowed-tools "Read,Glob,Grep,Bash(ls:*),Bash(cat:*),Bash(wc:*),Bash(stat:*),Bash(find:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git rev-parse:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh issue list:*)" \
+  > "$REPORT" 2>> "$LOG"
+
+EXIT=$?
+echo "[$(date -Iseconds)] vmm-rada-web-ui dreaming finished (exit=$EXIT, report=$REPORT)" >> "$LOG"
+
+if [[ $EXIT -ne 0 ]]; then
+  echo "[dreaming] non-zero exit; check $LOG" >&2
+  exit "$EXIT"
+fi
+
+SIZE=$(wc -c < "$REPORT")
+if [[ "$SIZE" -lt 500 ]]; then
+  echo "[dreaming] WARNING: report suspiciously small ($SIZE bytes); check $REPORT" >&2
+fi
+
+echo "[dreaming] OK: $REPORT ($SIZE bytes)"

--- a/.claude/dreaming/reports/.gitignore
+++ b/.claude/dreaming/reports/.gitignore
@@ -1,0 +1,2 @@
+# Run logs — local-only debug
+.dreaming.log

--- a/.claude/hooks/_lib/hook-common.sh
+++ b/.claude/hooks/_lib/hook-common.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Shared logging setup for Claude Code hooks installed via /generate-session-end.
+#
+# Usage: source this file, then call hook_setup_logging "<script-name>"
+# Sets LOG_FILE (global) and redirects stderr to the log + terminal.
+#
+# Log dir is per-project, derived from the repo name so each project's
+# hooks log separately (e.g. session-indexer -> ~/.cache/session-indexer/).
+# Override with HOOK_LOG_DIR.
+
+hook_setup_logging() {
+  local script_name="$1"
+  local project_name
+  project_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")")
+  # Never operate on the ~/.cache root itself (e.g. cwd=/ with no git → basename "/" → "/").
+  case "$project_name" in ""|"/"|".") project_name="session-end-hooks" ;; esac
+  LOG_DIR="${HOOK_LOG_DIR:-${HOME}/.cache/${project_name}}"
+  mkdir -p "$LOG_DIR" && chmod 700 "$LOG_DIR"
+  LOG_FILE="$LOG_DIR/hooks.log"
+  exec 2> >(tee -a "$LOG_FILE" >&2)
+  echo "[$(date -Iseconds)] $script_name invoked" >> "$LOG_FILE"
+}

--- a/.claude/hooks/eslint-fix.cjs
+++ b/.claude/hooks/eslint-fix.cjs
@@ -1,0 +1,24 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+const FRONTEND_ROOT = path.resolve(__dirname, "../..");
+
+let data = "";
+process.stdin.on("data", (chunk) => (data += chunk));
+process.stdin.on("end", () => {
+  try {
+    const json = JSON.parse(data);
+    const filePath =
+      json.tool_input?.file_path || json.tool_response?.filePath || "";
+    if (!/\.(js|jsx)$/.test(filePath)) return;
+    const resolved = path.resolve(filePath);
+    if (!resolved.startsWith(FRONTEND_ROOT + path.sep)) return;
+    execFileSync(
+      "npx",
+      ["eslint", "--fix", "--no-warn-ignored", resolved],
+      { cwd: FRONTEND_ROOT, stdio: "inherit" }
+    );
+  } catch (e) {
+    // Silently skip — don't block Claude's workflow
+  }
+});

--- a/.claude/hooks/precompact-emit-rules.sh
+++ b/.claude/hooks/precompact-emit-rules.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# PreCompact handler for vmm-rada-web-ui.
+#
+# Fires before context compaction (auto or manual /compact).
+# stdout is appended to the compactor's prompt as customInstructions —
+# it tells the summarization model what NOT to lose.
+#
+# Per source: claude-code/src/services/compact/compact.ts:413-423
+#   customInstructions = mergeHookInstructions(
+#     customInstructions,
+#     hookResult.newCustomInstructions,
+#   )
+
+set -euo pipefail
+
+# Log invocations for debugging — PreCompact runs in a forked agent, so its
+# output doesn't show in the main session transcript. Without this log, you
+# can't verify the hook fired. Remove if log noise becomes a problem.
+# shellcheck source=_lib/hook-common.sh
+source "$(dirname "$0")/_lib/hook-common.sh"
+hook_setup_logging "precompact-emit-rules.sh"
+
+# Path is relative to this script's location (.claude/hooks/ → .claude/).
+ESSENTIALS_FILE="$(dirname "$0")/../context-essentials.md"
+
+# Read hook input (we don't use it for now, but consume to avoid SIGPIPE)
+INPUT=$(cat)
+echo "[$(date -Iseconds)] precompact input: $(echo "$INPUT" | head -c 200)" >> "$LOG_FILE"
+
+if [[ -f "$ESSENTIALS_FILE" ]]; then
+  cat <<EOF
+When summarizing, ensure these vmm-rada-web-ui project rules are EXPLICITLY
+preserved in the summary's "Key Technical Concepts" section, even if they
+were only mentioned once or implicitly:
+
+$(cat "$ESSENTIALS_FILE")
+
+Also preserve:
+- All file paths that were read or modified during this session
+- Any user feedback containing "don't", "stop", "instead", "rather"
+- Active TodoWrite state
+- Tech Lead approval status of any in-progress plans
+- The current branch name and PR number (if any)
+EOF
+fi

--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+# Stop hook: appends/updates today's entry in .claude/session-log.md.
+#
+# Behaviour:
+#   - Skip if /session-end skill wrote the file within the last 2 hours
+#   - Generate summary: agy (Gemini) → opencode (cloud) → raw excerpt
+#   - If session-log.md already has an entry for today, replace it
+#   - Otherwise append; rotate to keep last 10 entries
+#
+# Output: .claude/session-log.md (gitignored, per-project)
+
+set -uo pipefail
+
+# shellcheck source=_lib/hook-common.sh
+source "$(dirname "$0")/_lib/hook-common.sh"
+hook_setup_logging "session-end.sh"
+
+INPUT=$(cat)
+echo "[$(date -Iseconds)] session-end invoked" >> "$LOG_FILE"
+
+LOG="$(dirname "$0")/../session-log.md"
+TODAY=$(date '+%Y-%m-%d')
+
+# Skip if /session-end skill already ran this session (file modified < 2h ago)
+if [[ -f "$LOG" ]]; then
+  AGE=$(( $(date +%s) - $(stat -c %Y "$LOG" 2>/dev/null || echo 0) ))
+  if [[ $AGE -lt 7200 ]]; then
+    echo "[$(date -Iseconds)] session-end: skill already ran (${AGE}s ago), skipping" >> "$LOG_FILE"
+    exit 0
+  fi
+fi
+
+# Locate session transcript
+TRANSCRIPT=$(echo "$INPUT" | python3 -c \
+  "import json,sys; d=json.load(sys.stdin); print(d.get('transcript_path',''))" 2>/dev/null || echo "")
+
+if [[ -z "$TRANSCRIPT" || ! -f "$TRANSCRIPT" ]]; then
+  PROJECT_HASH=$(pwd | sed 's|/|-|g')
+  TRANSCRIPT=$(ls -t "$HOME/.claude/projects/$PROJECT_HASH"/*.jsonl 2>/dev/null | head -1 || echo "")
+fi
+
+if [[ -z "$TRANSCRIPT" || ! -f "$TRANSCRIPT" ]]; then
+  echo "[$(date -Iseconds)] session-end: no transcript found, skipping" >> "$LOG_FILE"
+  exit 0
+fi
+
+# Extract last 30 exchanges from JSONL
+EXCERPT=$(python3 - "$TRANSCRIPT" <<'PYEOF'
+import json, sys
+
+messages = []
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+            msg = entry.get('message', {})
+            role = msg.get('role', '')
+            content = msg.get('content', '')
+            if role not in ('user', 'assistant'):
+                continue
+            text = ''
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get('type') == 'text':
+                        text += block.get('text', '')
+            elif isinstance(content, str):
+                text = content
+            text = text.strip()
+            if text:
+                messages.append(f"[{role}]: {text[:600]}")
+        except Exception:
+            pass
+
+print('\n\n'.join(messages[-30:]))
+PYEOF
+)
+
+if [[ -z "$EXCERPT" ]]; then
+  echo "[$(date -Iseconds)] session-end: empty transcript, skipping" >> "$LOG_FILE"
+  exit 0
+fi
+
+PROMPT="Write a session summary. Use exactly this structure (no preamble, start directly with the header):
+
+## $TODAY
+
+### Що зробили
+- completed items
+
+### Поточний стан
+- current branch / open PR / what works / what is broken
+
+### Відкриті питання
+- unresolved questions (omit this section entirely if none)
+
+### Наступні кроки
+- what to pick up next session, in priority order
+
+Rules: 10-20 bullets total, Ukrainian for content, English for code/file names/identifiers.
+
+SESSION TRANSCRIPT:
+$EXCERPT"
+
+# --- LLM call helpers ---
+
+try_agy() {
+  local models=(
+    "Gemini 3.5 Flash (Low)"
+    "Gemini 3.5 Flash (Medium)"
+    "Gemini 3.5 Flash (High)"
+    "Gemini 3.1 Pro (Low)"
+    "Gemini 3.1 Pro (High)"
+  )
+  command -v agy &>/dev/null || return 1
+  for model in "${models[@]}"; do
+    echo "[$(date -Iseconds)] session-end: trying agy model: $model" >> "$LOG_FILE"
+    local result
+    result=$(timeout 45 agy -p --model "$model" <<< "$1" 2>>"$LOG_FILE") && \
+      [[ -n "$result" ]] && { echo "$result"; return 0; }
+  done
+  return 1
+}
+
+# Write excerpt to temp file for opencode --file
+EXCERPT_TMP=$(mktemp /tmp/session-end-excerpt.XXXXXX)
+echo "$EXCERPT" > "$EXCERPT_TMP"
+trap 'rm -f "$EXCERPT_TMP"' EXIT
+
+OPENCODE_MSG="Summarize the session transcript in the attached file. Use exactly this structure (no preamble):
+
+## $TODAY
+
+### Що зробили
+- completed items
+
+### Поточний стан
+- current branch / open PR / what works / what is broken
+
+### Відкриті питання
+- unresolved questions (omit section if none)
+
+### Наступні кроки
+- what to pick up next session
+
+Rules: 10-20 bullets total, Ukrainian for content, English for code/file names."
+
+try_opencode() {
+  local models=(
+    "ollama/glm-5.2:cloud"
+    "ollama/kimi-k2.7-code:cloud"
+    "ollama/minimax-m3:cloud"
+    "ollama/qwen3.5:cloud"
+  )
+  command -v opencode &>/dev/null || return 1
+  for model in "${models[@]}"; do
+    echo "[$(date -Iseconds)] session-end: trying opencode model: $model" >> "$LOG_FILE"
+    local result
+    result=$(timeout 45 opencode run "$OPENCODE_MSG" \
+      --file "$EXCERPT_TMP" --model "$model" --format json 2>>"$LOG_FILE" | \
+      python3 -c "
+import json,sys
+parts=[]
+for line in sys.stdin:
+    line=line.strip()
+    if not line: continue
+    try:
+        obj=json.loads(line)
+        if obj.get('type')=='text':
+            parts.append(obj['part']['text'])
+    except: pass
+print(''.join(parts))
+") && [[ -n "$result" ]] && { echo "$result"; return 0; }
+  done
+  return 1
+}
+
+# --- Generate summary ---
+
+SUMMARY=""
+
+SUMMARY=$(try_agy "$PROMPT" 2>>"$LOG_FILE") || true
+
+if [[ -z "$SUMMARY" ]]; then
+  SUMMARY=$(try_opencode 2>>"$LOG_FILE") || true
+fi
+
+if [[ -z "$SUMMARY" ]]; then
+  echo "[$(date -Iseconds)] session-end: all LLMs failed, using raw excerpt" >> "$LOG_FILE"
+  SUMMARY="## $TODAY
+
+### Transcript excerpt (auto-summary unavailable)
+
+\`\`\`
+$(echo "$EXCERPT" | head -60)
+\`\`\`"
+fi
+
+# --- Append/update/rotate session-log.md ---
+
+python3 - "$LOG" "$TODAY" "$SUMMARY" <<'PYEOF'
+import sys, re, os
+
+log_file = sys.argv[1]
+today    = sys.argv[2]
+entry    = sys.argv[3].strip()
+max_keep = 10
+
+if not os.path.exists(log_file):
+    with open(log_file, 'w') as f:
+        f.write(entry + '\n')
+    sys.exit(0)
+
+with open(log_file) as f:
+    content = f.read()
+
+# Split on ## YYYY-MM-DD headers; keep each header with its content
+parts = re.split(r'(?m)(?=^## \d{4}-\d{2}-\d{2})', content)
+entries = [p.strip() for p in parts if p.strip()]
+
+today_header = f'## {today}'
+today_idx = next((i for i, e in enumerate(entries) if e.startswith(today_header)), -1)
+if today_idx >= 0:
+    entries.pop(today_idx)
+    entries.append(entry)           # replace today's entry, moved to end
+else:
+    entries.append(entry)           # new day
+
+entries = entries[-max_keep:]    # rotate — freshest write can never be trimmed away
+
+with open(log_file, 'w') as f:
+    f.write('\n\n'.join(entries) + '\n')
+PYEOF
+
+echo "[$(date -Iseconds)] session-end: wrote $(wc -l < "$LOG") lines to $LOG" >> "$LOG_FILE"

--- a/.claude/hooks/session-index.sh
+++ b/.claude/hooks/session-index.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Stop hook: indexes the session transcript into per-project SQLite via
+# session-indexer mine. Runs independently of session-end.sh so it fires
+# even when the summary step exits early (e.g. /session-end already ran).
+
+set -uo pipefail
+
+# shellcheck source=_lib/hook-common.sh
+source "$(dirname "$0")/_lib/hook-common.sh"
+hook_setup_logging "session-index.sh"
+
+INPUT=$(cat)
+
+TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || echo "")
+
+if [[ -z "$TRANSCRIPT" || ! -f "$TRANSCRIPT" ]]; then
+    echo "[$(date -Iseconds)] session-index: no transcript, skipping" >> "$LOG_FILE"
+    exit 0
+fi
+
+if ! command -v session-indexer >/dev/null 2>&1; then
+    echo "[$(date -Iseconds)] session-index: session-indexer not in PATH, skipping" >> "$LOG_FILE"
+    exit 0
+fi
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+DB="$PROJECT_ROOT/.claude/sessions.db"
+
+echo "[$(date -Iseconds)] session-index: mining $(basename "$TRANSCRIPT") → $DB" >> "$LOG_FILE"
+if session-indexer mine "$TRANSCRIPT" --db "$DB" >> "$LOG_FILE" 2>&1; then
+    echo "[$(date -Iseconds)] session-index: done" >> "$LOG_FILE"
+else
+    echo "[$(date -Iseconds)] session-index: session-indexer exited $?" >> "$LOG_FILE"
+fi

--- a/.claude/hooks/session-last.sh
+++ b/.claude/hooks/session-last.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# SessionStart hook: injects the most recent entry from .claude/session-log.md.
+#
+# Skips if the file doesn't exist or is empty. Rotation is count-based
+# (last 10 entries) — no age filtering here.
+
+set -euo pipefail
+
+# shellcheck source=_lib/hook-common.sh
+source "$(dirname "$0")/_lib/hook-common.sh"
+hook_setup_logging "session-last.sh"
+
+INPUT=$(cat)
+echo "[$(date -Iseconds)] session-last invoked" >> "$LOG_FILE"
+
+LOG="$(dirname "$0")/../session-log.md"
+
+if [[ ! -f "$LOG" ]]; then
+  echo "[$(date -Iseconds)] session-last: no session-log.md, skipping" >> "$LOG_FILE"
+  exit 0
+fi
+
+# Extract the last ## YYYY-MM-DD entry
+LAST_ENTRY=$(python3 - "$LOG" <<'PYEOF'
+import sys, re
+
+with open(sys.argv[1]) as f:
+    content = f.read()
+
+parts = re.split(r'(?m)(?=^## \d{4}-\d{2}-\d{2})', content)
+entries = [p.strip() for p in parts if p.strip()]
+if entries:
+    print(entries[-1])
+PYEOF
+)
+
+if [[ -z "$LAST_ENTRY" ]]; then
+  echo "[$(date -Iseconds)] session-last: empty log, skipping" >> "$LOG_FILE"
+  exit 0
+fi
+
+# Parse date from entry header (## YYYY-MM-DD) — used only for the age label
+ENTRY_DATE=$(echo "$LAST_ENTRY" | grep -oP '^## \K\d{4}-\d{2}-\d{2}' || echo "")
+if [[ -n "$ENTRY_DATE" ]]; then
+  ENTRY_TS=$(date -d "$ENTRY_DATE" +%s 2>/dev/null || echo 0)
+  NOW=$(date +%s)
+  AGE=$(( NOW - ENTRY_TS ))
+  AGE_DAYS=$(( AGE / 86400 ))
+  AGE_HOURS=$(( (AGE % 86400) / 3600 ))
+  AGE_LABEL="${AGE_DAYS}d ${AGE_HOURS}h ago"
+  [[ $AGE_DAYS -eq 0 ]] && AGE_LABEL="${AGE_HOURS}h ago"
+else
+  AGE_LABEL="(date unknown)"
+fi
+
+echo "[$(date -Iseconds)] session-last: injecting last entry ($AGE_LABEL)" >> "$LOG_FILE"
+
+jq -n \
+  --arg ctx "$LAST_ENTRY" \
+  --arg age "$AGE_LABEL" \
+  '{
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: ("Previous session context (" + $age + "):\n\n" + $ctx)
+    }
+  }'

--- a/.claude/hooks/session-recall.sh
+++ b/.claude/hooks/session-recall.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# SessionStart hook: injects semantically relevant past session context.
+# Derives a search query from git branch + recent commits, searches the
+# per-project session index (.claude/sessions.db), and injects matching
+# chunks as additionalContext.
+#
+# Complements session-last.sh (which injects the last structured entry).
+# This hook adds semantic recall across all indexed sessions.
+
+set -uo pipefail
+
+source "$(dirname "$0")/_lib/hook-common.sh"
+hook_setup_logging "session-recall.sh"
+
+if ! command -v session-indexer >/dev/null 2>&1; then
+    echo "[$(date -Iseconds)] session-recall: session-indexer not in PATH, skipping" >> "$LOG_FILE"
+    exit 0
+fi
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+DB="$PROJECT_ROOT/.claude/sessions.db"
+
+if [[ ! -f "$DB" ]]; then
+    echo "[$(date -Iseconds)] session-recall: no sessions.db yet, skipping" >> "$LOG_FILE"
+    exit 0
+fi
+
+# Derive search query from git context (branch name + recent commit messages)
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | sed 's/[_\/-]/ /g' || echo "")
+COMMITS=$(git log --oneline -3 2>/dev/null | cut -d' ' -f2- | tr '\n' ' ' || echo "")
+QUERY="$(printf '%s %s' "$BRANCH" "$COMMITS" | tr -s ' ' | sed 's/^ //;s/ $//')"
+
+if [[ -z "$QUERY" ]]; then
+    echo "[$(date -Iseconds)] session-recall: empty query, skipping" >> "$LOG_FILE"
+    exit 0
+fi
+
+echo "[$(date -Iseconds)] session-recall: query='${QUERY:0:80}'" >> "$LOG_FILE"
+
+RESULTS=$(session-indexer search "$QUERY" --db "$DB" --limit 5 --json 2>/dev/null || echo "[]")
+
+CONTEXT=$(printf '%s' "$RESULTS" | jq -r '
+  map(.Content = ((.Content // "") | gsub("^\\s+|\\s+$"; "")))
+  | map(select(
+    .Content | test("^(Bash|Read|Write|Edit|Glob|Grep|WebFetch|WebSearch|Agent|Task)\\s*\\{") | not
+  ))
+  | group_by(.SessionDate // "unknown")
+  | map({date: (.[0].SessionDate // "unknown"), chunks: (sort_by(.Score) | reverse | .[0:2])})
+  | sort_by(.date) | reverse | .[0:3]
+  | .[]
+  | "### \(.date)",
+    (.chunks[] | "  [\(.Score | tostring | .[0:5])] \(.Content[0:280])\(if (.Content | length) > 280 then "..." else "" end)"),
+    ""
+' 2>/dev/null | sed 's/[[:space:]]*$//')
+
+if [[ -z "$CONTEXT" ]]; then
+    echo "[$(date -Iseconds)] session-recall: no usable results after filtering" >> "$LOG_FILE"
+    exit 0
+fi
+
+echo "[$(date -Iseconds)] session-recall: injecting context" >> "$LOG_FILE"
+
+jq -n --arg ctx "$CONTEXT" '{
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: ("Relevant past sessions (semantic search):\n\n" + $ctx)
+  }
+}'

--- a/.claude/hooks/session-restore-rules.sh
+++ b/.claude/hooks/session-restore-rules.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# SessionStart handler for vmm-rada-web-ui with matcher='compact'.
+#
+# Fires when a session resumes AFTER compaction. Returns JSON whose
+# additionalContext is injected into the new session.
+#
+# Per source: claude-code/src/utils/hooks.ts:643-647
+#   case 'SessionStart':
+#     result.additionalContext = json.hookSpecificOutput.additionalContext
+
+set -euo pipefail
+
+# Log invocations for debugging. Symmetric with precompact-emit-rules.sh.
+# shellcheck source=_lib/hook-common.sh
+source "$(dirname "$0")/_lib/hook-common.sh"
+hook_setup_logging "session-restore-rules.sh"
+
+# Path is relative to this script's location (.claude/hooks/ → .claude/).
+ESSENTIALS_FILE="$(dirname "$0")/../context-essentials.md"
+
+# Consume input to avoid SIGPIPE
+INPUT=$(cat)
+echo "[$(date -Iseconds)] session-restore input: $(echo "$INPUT" | head -c 200)" >> "$LOG_FILE"
+
+if [[ -f "$ESSENTIALS_FILE" ]]; then
+  jq -n --arg ctx "$(cat "$ESSENTIALS_FILE")" '{
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: ("Session resumed after compaction. vmm-rada-web-ui critical rules re-injected:\n\n" + $ctx)
+    }
+  }'
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,55 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/eslint-fix.cjs",
+            "timeout": 15,
+            "statusMessage": "Running eslint --fix on changed file..."
+          },
+          {
+            "type": "prompt",
+            "prompt": "A file was just edited or written. If this change introduces a new pattern, convention, reusable approach, or catches a non-obvious mistake, briefly remind the user to log it via /self-learn log. One sentence max. Only mention if genuinely worth remembering.",
+            "statusMessage": "Checking for pattern logging..."
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "auto|manual",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/precompact-emit-rules.sh",
+            "timeout": 10,
+            "statusMessage": "Emitting context-essentials to compactor..."
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/session-restore-rules.sh",
+            "timeout": 10,
+            "statusMessage": "Re-injecting vmm-rada-web-ui context-essentials..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/apply-dreaming/SKILL.md
+++ b/.claude/skills/apply-dreaming/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: apply-dreaming
+description: "Read the latest vmm-rada-web-ui dreaming report and apply
+  high-confidence findings. Routes findings through the project's
+  standard /backlog → Tech Lead → /ship → /fix-review workflow for
+  code-touching changes AND for changes to load-bearing .claude/
+  files (agent prompts, context-essentials). Direct edit only for
+  agent-local memory and tooling scripts. Annotates report with
+  [applied YYYY-MM-DD] markers."
+user-invocable: true
+argument-hint: "[week|latest]"
+---
+
+# /apply-dreaming (vmm-rada-web-ui)
+
+Walks each dreaming-report finding interactively and leaves an audit
+trail (`[applied YYYY-MM-DD]` / `[planned …]` / `[skipped …]` markers
+appended to the report).
+
+## When to invoke
+
+- Monday morning after Sunday 05:30 cron-run produced a fresh report.
+- Or any time after a manual `.claude/dreaming/dreaming.sh` run.
+- Or `/apply-dreaming` (with optional `latest` or `2026-W##` argument).
+
+## Inputs
+
+- Optional argument: `latest` (default) or `YYYY-W##`.
+- Project root: `~/wrk/projects/vmm-rada-web-ui/vmm-rada-web-ui/`.
+
+## Steps
+
+### 1. Locate report
+
+```bash
+WEEK="${1:-latest}"
+DIR=".claude/dreaming/reports"
+if [[ "$WEEK" == "latest" ]]; then
+  REPORT=$(ls -1t "$DIR"/2026-W*.md 2>/dev/null | head -1)
+else
+  REPORT="$DIR/$WEEK.md"
+fi
+```
+
+### 2. Parse into structured items
+
+Read REPORT. For each numbered sub-item, extract:
+
+- `id`, `title`, `confidence` (high/medium/low)
+- `evidence` — paths/commits/PRs cited
+- `suggestion`
+- `category` — infer from suggestion verb:
+  - "add to context-essentials" → `update-rules`
+  - "rewrite memory / refresh stale facts" → `update-memory`
+  - "merge / consolidate agents" → `update-agents`
+  - "add new skill" → `add-skill`
+  - "fix broken /ship workflow / `gh` invocation" → `fix-tooling`
+  - "code change / refactor / fix bug" → `code-change`
+  - else → `other`
+
+**Confidence inheritance.** Reports state confidence at the **section
+level** (e.g. `§2 — confidence: high`), not always per item. When a
+sub-item has no explicit `confidence` field, inherit it from the
+enclosing section. Default to `medium` only when neither item nor
+section declares a level.
+
+**Idempotency — skip already-marked items.** If the next non-blank
+line after an item starts with `> [applied …]`, `> [planned …]`,
+`> [skipped …]`, or `> [manual-review-required …]`, skip the item
+silently. The report is appended to (never rewritten) on each pass,
+so re-running `/apply-dreaming` on the same report processes only
+new items. Print a summary line at the start: `2026-W##: M new
+items (N already-processed skipped)`.
+
+### 3. Show TL;DR + counts
+
+```
+2026-W##: N items (X high, Y medium, Z low)
+TL;DR: ...
+Process all? [y/select/skip-low/abort]
+```
+
+### 4. Triage walk
+
+Iterate `high → medium → low`. For each item:
+
+```
+[H 1/N] §<id>  <title>
+  Evidence: <paths/commits>
+  Suggestion: <suggestion>
+  
+  [a]pply / [s]kip / [v]erify-first / [e]vidence / [q]uit
+```
+
+For `low`: skip silently unless user opted in.
+
+### 5. Apply per category
+
+**Routing rule.** Two paths only:
+- **Plan-and-gate path** for anything load-bearing on agent or runtime
+  behaviour: `code-change`, `update-rules` (context-essentials),
+  `update-agents` (agent prompts), `add-skill`. These all draft a plan
+  and route through `/backlog → Tech Lead → /ship → /fix-review`.
+- **Direct-edit path** only for non-load-bearing artefacts:
+  `update-memory` (agent-local memory, often gitignored) and
+  `fix-tooling` (`.claude/dreaming/*.sh`, `.claude/hooks/*.sh`,
+  internal helper scripts that don't change agent prompts).
+
+Agent prompts and `context-essentials.md` ARE the runtime for the
+agent workflow — including the Tech Lead. Editing them without a
+gate would let dreaming reports silently steer the very agent that
+should review the change. Always plan-and-gate.
+
+#### `update-rules` / `update-agents` / `add-skill` — plan-and-gate
+
+Same as `code-change` (see below). Draft a plan that cites the
+dreaming finding; route through `/backlog`. Tech Lead reviews the
+proposed change to load-bearing infrastructure before it lands.
+
+#### `update-memory` — agent-memory/<agent>/<file>.md (direct)
+
+Agent-local files (often gitignored under `.claude/agent-memory/`). This
+directory doesn't exist yet in a fresh checkout — it's created the first
+time an agent writes to its own memory. If a dreaming finding is
+categorized `update-memory` but the target directory doesn't exist,
+treat it as `other` (manual review) instead of erroring.
+
+1. Read target memory file.
+2. Apply suggested changes (rewrite if "stale", append if "missing").
+3. Set `last-verified: <today>` in frontmatter.
+4. Skip commit unless `.claude/agent-memory/` is git-tracked here
+   (check `git check-ignore` first).
+
+#### `fix-tooling` — scripts under .claude/ (direct + PR)
+
+For helper scripts (`dreaming.sh`, hook scripts, etc.) that don't
+embed agent prompts:
+
+1. Create branch: `git switch -c fix/dreaming-W##-<slug>`.
+2. Edit script.
+3. Smoke-test: `bash -n <script>` for syntax; run with sample input
+   if the script has a dry-run mode.
+4. Commit, push, PR.
+
+#### `code-change` — plan-and-gate
+
+Substantive code changes (or any of the plan-and-gate categories
+above) go through the project's standard workflow. **Don't edit
+directly.** Instead:
+
+1. Draft a plan file referencing the dreaming finding:
+   `.claude/plans/<priority>-dreaming-W##-<slug>.md`
+2. Plan frontmatter: `type`, `priority`, `labels`, `github_issue: ""`.
+3. Plan body: cite report §<id>, evidence, suggested change, files
+   to touch, acceptance criteria.
+4. Tell user: "Created plan `<priority>-dreaming-W##-<slug>`. Run
+   `/backlog <slug>` to gate it through Tech Lead — pass the **slug
+   without the priority prefix** so `/backlog` finds the existing
+   plan rather than drafting a fresh one. Then `/ship` for
+   implementation."
+
+#### `other` — manual review
+
+Print suggestion + evidence. Don't apply. Annotate
+`[manual-review-required 2026-MM-DD]`.
+
+### 6. Annotate report
+
+After each applied item, append (don't modify original):
+
+```markdown
+> [applied 2026-MM-DD: <action>; commit <sha>; PR <num>]
+```
+
+For created plans:
+```markdown
+> [planned 2026-MM-DD: .claude/plans/<file>; awaiting /backlog]
+```
+
+For skipped:
+```markdown
+> [skipped 2026-MM-DD: <reason>]
+```
+
+### 7. Final summary
+
+```
+Applied: N (direct edits on .claude/ tooling)
+Plans created: M (awaiting /backlog → Tech Lead → /ship)
+Manual review: K
+Skipped: P
+
+PRs opened: <list>
+Plans pending: <list>
+Backup: /tmp/dreaming-W##-vmm-rada-web-ui-backup-HHMM/
+
+Next steps:
+1. Watch PRs for /fix-review multi-model rounds.
+2. Run /backlog on each plan to gate through Tech Lead.
+3. Run /ship on approved plans.
+```
+
+## Constraints (CRITICAL)
+
+- **NEVER push to main directly** — branch protection requires PR.
+- **NEVER auto-apply low confidence** without explicit request.
+- **NEVER skip Tech Lead gate for code-changes** — route through plans.
+- **ALWAYS backup before destructive operations**.
+- **ALWAYS cite report-section** in commit messages and PR body.
+- **One PR per category-batch** (don't mix `update-rules` with
+  `update-agents` in the same PR — different review focus).
+- **Confirm before destructive ops** even at high confidence.
+
+## Anti-patterns
+
+- ❌ Edit code on main directly (will fail branch protection).
+- ❌ Skip plan creation for code-changes (Tech Lead gate is mandatory).
+- ❌ Mix tooling and code changes in one PR.
+- ❌ Modify report's original suggestions (annotate only).
+- ❌ Apply CORS-style "false claims" findings without verifying against
+  current code first (the dreaming pass can be wrong; verify first).
+
+## Companion skills
+
+- `/backlog` — gate plans through Tech Lead.
+- `/ship` — implement approved plan + create PR.
+- `/fix-review` — multi-model review rounds + Claude arbiter.
+- `/revival` — health snapshot (synchronous, complementary to dreaming).
+
+## See also
+
+- `.claude/dreaming/dreaming-prompt.md` — what the dreaming pass looks for.
+- `.claude/dreaming/README.md` — how the dreaming script is wired and run.
+- `.claude/context-essentials.md` — load-bearing rules (target of many
+  promote-to-rules suggestions).

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -166,7 +166,7 @@ Execute the plan exactly. After implementation:
 
 - [ ] `npm run lint` passes
 - [ ] Manual smoke test
-- [ ] `/ship` — PR, Copilot review, one fix round, squash merge (`Closes #N` in PR body), checkout main
+- [ ] `/ship` — PR, `/fix-review` (multi-model + arbiter), squash merge (`Closes #N` in PR body), checkout main
 - [ ] `docs-maintainer` if SSE events, REST endpoints, or architecture changed
 
 ### 7. Close issue on merge

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -1,220 +1,250 @@
 ---
 name: fix-review
-description: Address Copilot review comments on the current open PR, or review and merge a Dependabot PR. For Dependabot: checks semver bump level, changelog, and breaking changes before merging. No Copilot wait required.
+description: Multi-model PR review pipeline. Dispatches the diff concurrently to 3 reviewer models (config.yaml), tallies vote counts per finding (informational), then Claude acts as arbiter (CONFIRM / DISMISS / DEFER) and merges when clean. Invoke with an optional PR number (defaults to the current branch's open PR). Dependabot PRs are handled by the global dependabot-reviewer agent, not this skill.
 user-invocable: true
-argument-hint: "[pr-number] — defaults to the PR for the current branch"
+argument-hint: "[pr-number]"
 metadata:
-  version: "1.3"
-  author: frontend-claude
-  last_updated: "2026-03-22"
+  version: "2.0.0"
+  domain: code-review
+  scope: quality-gate
+  debt-level: balanced
 ---
 
 # /fix-review
 
-## Entry: detect PR type
+Multi-model PR review pipeline for vmm-rada-web-ui.
+
+For Dependabot PRs, use the global `dependabot-reviewer` agent
+(`~/.claude/agents/dependabot-reviewer.md`) instead — risk-based SemVer
+triage, not this pipeline.
+
+## Code Review Pyramid (arbiter evaluates in this order — base first)
+
+```
+        ▲
+       /5\    Style       → NEVER flagged — ESLint handles this
+      /---\
+     / 4   \  Tests       → Critical paths covered? (Vitest + Testing Library)
+    /-------\
+   /    3    \ Docs        → Complex logic explained?
+  /           \
+ /      2      \ Implementation → Bugs, null checks, stale closures, SSE
+/_______________\                 handling, XSS/security, performance
+       1          Architecture   → Adapter-boundary violations, state
+                                    writes outside App.jsx, raw HTML
+                                    rendering of LLM output
+```
+
+**Priority:** Layer 1 errors → Layer 1 warnings → Layer 2 errors → Layer 2 warnings → Layer 3–4 → suggestions. An architectural flaw makes implementation fixes irrelevant — always fix from the base up.
+
+**Layer 1 checks are the four immutable rules in `.claude/context-essentials.md`** — components stay pure UI, `src/api.js` is the sole adapter boundary, `App.jsx` owns all state, `react-markdown` is the only LLM-output renderer. Treat any diff that violates these as a Layer 1 error regardless of what the reviewer models flag.
+
+## Pipeline
+
+```
+Concurrent dispatch (config.yaml reviewers.openrouter.*):
+  Reviewer model 1 (round_1) ──┐
+  Reviewer model 2 (round_2) ──┼──→ JSON findings arrays
+  Reviewer model 3 (round_3) ──┘
+       ↓
+  Vote tally: group by file:line, attach count N/3 (informational only)
+  All findings reach the arbiter — votes do not gate
+       ↓
+  Arbiter (Claude, main instance)
+    → full diff + all findings with vote metadata
+    → CONFIRM / DISMISS / DEFER each finding
+    → fix CONFIRM findings → commit+push
+    → post PR comment with vote table
+    → merge if no CONFIRM blockers remain
+```
+
+Note: `config.yaml` uses `round_1/round_2/round_3` keys for historical reasons — these
+are concurrent dispatches, not sequential rounds. The models to use are always read from
+`config.yaml`; do not hardcode model names here.
+
+CLI failover tier (config.yaml `reviewers.cli`) engages automatically when the Ollama
+cloud endpoint probe fails — same flow, local models instead of cloud.
+
+## Step-by-step execution
+
+### 0. Resolve PR
+
+If an argument was given, use that PR number. Otherwise run:
+```bash
+gh pr view --json number,headRefName,state,author
+```
+Confirm the PR is open. If `author.login == "dependabot[bot]"`, stop and
+tell the user to invoke the `dependabot-reviewer` agent instead — this
+skill is for human-authored PRs. Store the PR number as `$PR`.
+
+### 1. Fetch the full diff
 
 ```bash
-gh pr view <number> --json author,title,headRefName,body
+gh pr diff $PR
 ```
 
-- If `author.login == "dependabot[bot]"` → follow **Dependabot flow** below.
-- Otherwise → follow **Copilot review flow** below.
+Store it as the **baseline diff** (used in dispatch and arbiter pass).
 
----
+### 2. Load reviewer config
 
-## Dependabot flow
+Read `.claude/skills/fix-review/config.yaml`. Extract:
+- `reviewers.openrouter.round_1/2/3` — cloud reviewer models
+- `openrouter_api_url` — Ollama endpoint (`http://localhost:11434/v1/chat/completions`)
+- `reviewers.cli` — local failover models (used if cloud endpoint unreachable)
 
-No Copilot wait needed — bump level determines the workflow: patches can be merged immediately, while minor and major bumps require the checks described below (with major bumps always closed after creating a tracking issue).
+First, extract the actual model names you just read from `config.yaml`:
+```bash
+# Use the exact model name strings from reviewers.openrouter.round_1/2/3
+ROUND1="<exact round_1 model string>"   # e.g. qwen3.5:cloud
+ROUND2="<exact round_2 model string>"   # e.g. minimax-m2.7:cloud
+ROUND3="<exact round_3 model string>"   # e.g. gemma4:31b-cloud
+```
 
-### 1. Read the PR
+Then probe the endpoint:
+```bash
+MODELS_JSON=$(curl -sf --max-time 5 http://localhost:11434/v1/models 2>/dev/null)
+
+if [ -z "$MODELS_JSON" ]; then
+  TIER="cli"
+  echo "⚠️  Ollama endpoint unreachable — using CLI tier"
+else
+  # Extract model IDs robustly (handles spaces after colon in JSON)
+  AVAILABLE=$(echo "$MODELS_JSON" | grep -oP '"id"\s*:\s*"\K[^"]+')
+  if echo "$AVAILABLE" | grep -qF "$ROUND1" \
+     || echo "$AVAILABLE" | grep -qF "$ROUND2" \
+     || echo "$AVAILABLE" | grep -qF "$ROUND3"; then
+    TIER="cloud"
+  else
+    TIER="cli"
+    echo "⚠️  Ollama online but none of the configured models loaded — using CLI tier"
+    echo "    Expected one of: $ROUND1 | $ROUND2 | $ROUND3"
+  fi
+fi
+```
+
+If `TIER="cli"` for any reason → use CLI failover tier (`reviewers.cli`).
+
+### 3. Concurrent review dispatch
+
+Build the review prompt combining the baseline diff with instructions:
+
+> "Review this PR diff. Return ONLY a raw JSON array of findings — no prose, no markdown
+> fences. Each finding: `{\"file\": \"path\", \"line\": N, \"layer\": 1-5, \"severity\":
+> \"error|warn|sugg\", \"description\": \"...\"}`. Flag only real issues per the Code
+> Review Pyramid. Layer 5 (style) is never flagged."
+
+Send the prompt to each reviewer model via `ollama-review.sh`:
 
 ```bash
-gh pr view <number> --json title,body,headRefName
+PROMPT="<diff + instructions>"
+
+R1=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_1_model>)
+R2=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_2_model>)
+R3=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_3_model>)
 ```
 
-Extract: package name, old version, new version.
+Each call returns a JSON array (empty `[]` on parse failure — safe degradation).
 
-### 2. Classify the bump
+### 4. Tally findings
 
-| Bump | Action |
-|------|--------|
-| **patch** (x.y.Z) | Merge immediately — no review needed |
-| **minor** (x.Y.z) | Scan changelog/release notes for deprecations or behaviour changes; merge if clean |
-| **major** (X.y.z) | Read migration guide, write a plan file, invoke `/backlog` to create a tracking issue, close the PR without merging |
+Merge all three arrays. Group findings by `file:line`. For each unique `file:line`,
+count how many of the 3 models flagged it.
 
-### 3. Check for breakage (minor and major)
+Attach `votes: N/3` to each finding as **informational metadata only**. All findings
+(even `votes: 1/3`) are passed to the arbiter — vote counts are a confidence signal,
+not a gate. The arbiter's dismiss rate (~80%) is the actual filter.
 
-- Read the package's CHANGELOG or GitHub release notes (use WebFetch if needed).
-- Grep the codebase for any API surfaces flagged as removed/changed:
-  ```bash
-  grep -r "<symbol>" src/
-  ```
-- If breaking usage is found for **minor**: report to the user, do not merge.
-- For **major**: always proceed to step 3a regardless of whether breaking usage is found.
+### 5. Arbiter pass (Claude, main instance)
 
-### 3a. Major bump — write plan, create issue, close PR
-
-1. **Write a plan file** to `.claude/plans/1-migrate-<package>-v<N>.md` where `<package>` is a slugified package name (strip leading `@`, replace `/` with `-`; e.g. `@scope/name` → `scope-name`):
-
-```markdown
----
-title: "Migrate <package> from v<old> to v<new>"
-type: chore
-priority: p1-high
-status: ready
-debt: balanced
-effort: m
-component:
-  - dx
-labels:
-  - chore
-  - p1-high
-  - dx
-  - deps
-blocked_by: null
-github_issue: null
-created: <YYYY-MM-DD>
-updated: <YYYY-MM-DD>
----
-```
-
-   Plan body (implementation details only — no Summary/AC, those go in the issue):
-   - Files to change (from grep results)
-   - Breaking API changes found in the migration guide
-   - Step-by-step migration approach
-   - Risks and unknowns
-
-2. **Invoke `/backlog` for the just-created plan**:
-   - Run `/backlog` with no arguments.
-   - When prompted to choose a plan file, enter the path to the plan you just created (e.g. `.claude/plans/1-migrate-<package>-v<new>.md`).
-   - Confirm creation of the GitHub issue when `/backlog` asks.
-   - `/backlog` will deduplicate, create the GitHub issue, and delete the plan file. Record the issue number it returns.
-
-3. **Comment on the Dependabot PR** referencing the issue:
-   ```bash
-   gh pr comment <number> --body "Major version bump — migration tracked in #<issue>. Closing this PR; Dependabot will reopen when ready to merge."
-   ```
-
-4. **Close the Dependabot PR** without merging:
-   ```bash
-   gh pr close <number>
-   ```
-
-5. **Report** — package, old → new, issue number created, PR closed.
-   Stop here. Do not merge. The migration issue is now in the backlog.
-
-### 4. Merge (patch / clean minor only)
-
+Re-fetch the full diff post-dispatch (should be unchanged, but confirms branch state):
 ```bash
-gh pr merge <number> --merge
+gh pr diff $PR
 ```
 
-Use `--merge` (not squash) to preserve Dependabot's commit for auditability.
+For each finding (ordered Layer 1 first), apply the Code Review Pyramid:
 
-### 5. Return to main
+| Ruling | Meaning | Action |
+|--------|---------|--------|
+| **CONFIRM** | Real issue, correctly identified | Fix it |
+| **ESCALATE** | Real issue, more severe than flagged | Fix it, note severity upgrade |
+| **DISMISS** | False positive or conflicts with project patterns | Skip, note reason |
+| **DEFER** | Valid concern, out of scope for this PR | Create a GitHub issue |
 
+Also run an **independent scan** of the full diff — look for anything the models missed,
+especially violations of the four immutable rules in `context-essentials.md` (a direct
+`fetch`/`api.js` call from a component, a state write outside `App.jsx`, raw HTML
+rendering of LLM output, a new competing renderer).
+
+For CONFIRM/ESCALATE findings:
+1. Apply the fix using Edit.
+2. Commit + push:
+```bash
+git add <files>
+git commit -m "fix(pr#$PR): arbiter — address confirmed findings"
+git push
+```
+
+For DEFER findings:
+```bash
+gh issue create --title "..." --body "..."
+```
+
+### 6. Post PR comment
+
+Post a single collapsible summary:
+
+```
+<details>
+<summary>/fix-review — parallel pass · N findings · N confirmed · N dismissed · N deferred</summary>
+
+| File:Line | Votes | Layer | Sev | Ruling | Note |
+|-----------|-------|-------|-----|--------|------|
+| src/components/Stage2.jsx:42 | 2/3 | 2 | error | CONFIRM | missing null check on metadata.label_to_model |
+| src/api.js:87 | 1/3 | 5 | sugg | DISMISS | style — not flagged by pyramid |
+
+Models: <round_1_model>, <round_2_model>, <round_3_model> (from config.yaml)
+Arbiter: Claude Sonnet 4.6
+
+</details>
+```
+
+### 7. Merge decision
+
+Run before merging:
+```bash
+npm run lint
+npm test
+```
+Block merge if either fails.
+
+**Proceed to merge** if:
+- No unresolved CONFIRM blockers remain
+- All High-severity security findings are CONFIRM (fixed) or DISMISS (justified)
+- `npm run lint` and `npm test` both pass
+
+**Block merge** if:
+- Any unfixed High-severity security finding exists
+- Lint or tests fail
+
+Merge with squash:
+```bash
+gh pr merge $PR --squash --delete-branch
+```
+
+Then sync main:
 ```bash
 git checkout main && git pull
 ```
 
-### 6. Report
+## Exit conditions
 
-Package, old → new version, bump level, any findings, merge commit or reason blocked.
-
----
-
-## Copilot review flow
-
-### Code Review Pyramid
-
-All Copilot comments are classified by pyramid layer before fixing. Fix from the bottom up — highest value is at the base.
-
-```
-        ▲
-       /5\         Style          → NEVER fixed — automated by ESLint
-      /---\
-     / 4   \       Tests          → N/A (no test suite)
-    /-------\
-   /    3    \     Documentation  → Is complex logic explained?
-  /           \
- /      2      \   Correctness    → Bugs, null checks, stale closures, security, performance
-/_______________\
-       1          Architecture   → SSE adapter boundary, App.jsx state model, design flaws
-```
-
-**Fix priority order (within a PR):**
-1. Layer 1 errors
-2. Layer 1 warnings
-3. Layer 2 errors
-4. Layer 2 warnings
-5. Layer 3 issues
-6. Suggestions (any layer)
-
-**Why this order matters:** An architectural flaw (Layer 1) can make correctness fixes (Layer 2) irrelevant — polishing broken scaffolding. Fix the foundation first.
-
-### Layer Reference
-
-| Layer | Concern | Examples |
-|-------|---------|---------|
-| **1** | Architecture & design | SSE adapter boundary violation, state mutation outside App.jsx, wrong abstraction |
-| **2** | Correctness | Bugs, null handling gaps, missing error branches, stale closures, race conditions, security |
-| **3** | Documentation | Complex logic without comment, misleading naming, undocumented non-obvious behaviour |
-| **4** | Tests | N/A — project has no test suite |
-| **5** | Style | Formatting — automated by ESLint, **never hand-fixed** |
-
-### Rules
-
-- Process **one round** of Copilot comments only. Do not loop waiting for a second review.
-- If a comment conflicts with project decisions (CLAUDE.md, memory), note the conflict and skip rather than blindly applying.
-- If the PR has no unresolved Copilot comments, report that and stop.
-
-### Rulings
-
-For each comment, assign a ruling before deciding what to do:
-
-| Ruling | Meaning | Action |
-|--------|---------|--------|
-| **CONFIRM** | Real issue, model was right | Fix it |
-| **ESCALATE** | Real issue, more severe than flagged | Fix it, note severity upgrade |
-| **DISMISS** | False positive or conflicts with project patterns | Skip, note reason |
-| **DEFER** | Real but out of scope for this PR | Log only, do not fix |
-
-### Steps
-
-1. **Find the PR** — use the argument if given, otherwise detect from current branch:
-   ```bash
-   gh pr view --json number,title,headRefName
-   ```
-
-2. **Read all Copilot comments:**
-   ```bash
-   gh pr view <number> --json reviews,comments
-   gh api repos/{owner}/{repo}/pulls/<number>/comments
-   ```
-   Filter to comments from `copilot-pull-request-reviewer` or `github-advanced-security`.
-
-3. **Classify each comment** by pyramid layer. Sort by fix priority order before implementing.
-
-4. **Implement fixes** — read the relevant files, apply changes. Keep fixes minimal (⚡ scope unless the comment explicitly requests more). Do not refactor surrounding code.
-
-5. **Lint:**
-   ```bash
-   npm run lint
-   ```
-   Fix any new lint errors introduced.
-
-6. **Commit and push:**
-   ```bash
-   git add <changed files>
-   git commit -m "fix-review: address Copilot comments"
-   git push
-   ```
-
-7. **Report** — list each comment with its ruling (CONFIRM/ESCALATE/DISMISS/DEFER) and what was done. Note any comments skipped and why.
-
-## What NOT to do
-
-- Do not merge the PR — that is `/ship`'s job (except Dependabot patches/minor above).
-- Do not wait for a new Copilot review cycle.
-- Do not open new issues or PRs.
-- Do not fix Layer 5 (style) comments — ESLint handles those.
+| State | Action |
+|-------|--------|
+| All findings arbitrated, no blockers | Merge |
+| Cloud endpoint unreachable | Fall back to CLI tier, proceed |
+| Model returns non-JSON | Treat as 0 findings for that model, proceed |
+| Round fails to push | Stop, report error to user |
+| PR already merged | Report and exit |
+| PR has merge conflicts | Stop, ask user to resolve |
+| `npm run lint` or `npm test` fails | Fix if trivial and in scope, else block merge and report |
+| PR authored by dependabot[bot] | Stop, direct user to `dependabot-reviewer` agent |

--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -1,0 +1,46 @@
+# vmm-rada-web-ui project-level fix-review config.
+# Overrides ~/.claude/skills/fix-review/config.yaml for this repo.
+# Provider: Ollama (cloud models via local endpoint — no OpenRouter key needed).
+
+provider: ollama
+
+# Load API key from this env var instead of the default OPENROUTER_API_KEY.
+# AI_PROVIDER_API_KEY is set in .env; Ollama ignores the auth header but
+# the value must be non-empty to pass the skill's key-presence check.
+api_key_env: AI_PROVIDER_API_KEY
+
+reviewers:
+  openrouter:
+    round_1: { model: qwen3.5:cloud }               # coding-focused, cloud quality
+    round_2: { model: minimax-m2.7:cloud }          # MiniMax, non-thinking, long-ctx
+    round_3: { model: gemma4:31b-cloud }            # Gemma code model, non-thinking
+
+  # Local failover tier — tools-capable models, no network dependency.
+  # Engages automatically when the Ollama cloud endpoint probe fails.
+  # ollama-review.sh reads the prompt from stdin, calls the OpenAI-compat
+  # endpoint, and returns the model's raw content (JSON array expected).
+  cli:
+    - name: qwen3-coder-30b
+      cmd: "bash .claude/skills/fix-review/ollama-review.sh qwen3-coder:30b"
+    - name: qwen2.5-coder-7b
+      cmd: "bash .claude/skills/fix-review/ollama-review.sh qwen2.5-coder:7b"
+    - name: granite3.3-8b
+      cmd: "bash .claude/skills/fix-review/ollama-review.sh granite3.3:8b"
+
+# Ollama OpenAI-compat endpoint — used instead of the OpenRouter default.
+# chat_payload_system + chat_content in rest.sh both work here since the
+# /v1 endpoint returns .choices[0].message.content (OpenAI format).
+openrouter_api_url: http://localhost:11434/v1/chat/completions
+
+post_summary_to_pr: true
+telemetry_enabled: true
+
+pricing:
+  # Active cloud reviewers (reviewers.openrouter.round_1/2/3)
+  "qwen3.5:cloud":       { input: 0.00, output: 0.00 }
+  "minimax-m2.7:cloud":  { input: 0.00, output: 0.00 }
+  "gemma4:31b-cloud":    { input: 0.00, output: 0.00 }
+  # Local failover models (reviewers.cli)
+  "qwen3-coder:30b":  { input: 0.00, output: 0.00 }
+  "qwen2.5-coder:7b": { input: 0.00, output: 0.00 }
+  "granite3.3:8b":    { input: 0.00, output: 0.00 }

--- a/.claude/skills/fix-review/ollama-review.sh
+++ b/.claude/skills/fix-review/ollama-review.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# CLI-tier helper for /fix-review.
+# Reads the review prompt from stdin, calls a local Ollama model via the
+# OpenAI-compat endpoint, and writes the model's raw content to stdout.
+# The parent skill expects a JSON array on stdout; non-JSON output is treated
+# as 0 findings for this round (safe degradation).
+#
+# Usage (in config.yaml cli.cmd):
+#   bash .claude/skills/fix-review/ollama-review.sh <model>
+
+set -euo pipefail
+
+MODEL="${1:?usage: $0 <model>}"
+BASE_URL="${OLLAMA_HOST:-http://localhost:11434}"
+SYS="Your entire response MUST be a raw JSON array — nothing else. Start with [ and end with ]. No prose, no markdown fences."
+PROMPT=$(cat)
+
+# Some cloud models return empty content on large prompts under load (no
+# error, just a truncated/empty response body) — observed repeatedly with
+# qwen3.5:cloud on full-diff review prompts. Retry once with a smaller
+# max_tokens cap before giving up.
+call_model() {
+  local max_tokens="$1"
+  curl -sf --max-time 180 \
+    "${BASE_URL}/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n \
+          --arg m "$MODEL" --arg sys "$SYS" --arg usr "$PROMPT" --argjson mt "$max_tokens" \
+          '{model:$m,messages:[{role:"system",content:$sys},{role:"user",content:$usr}],stream:false,max_tokens:$mt}')" \
+    | jq -r '.choices[0].message.content // empty'
+}
+
+CONTENT=$(call_model 4096 || true)
+
+if [ -z "$(printf '%s' "$CONTENT" | tr -d '[:space:]')" ]; then
+  echo "warn: $MODEL returned empty content — retrying once" >&2
+  CONTENT=$(call_model 2048 || true)
+fi
+
+printf '%s' "${CONTENT:-[]}"

--- a/.claude/skills/session-end/SKILL.md
+++ b/.claude/skills/session-end/SKILL.md
@@ -1,0 +1,160 @@
+# /session-end
+
+Manages `.claude/session-log.md` — a per-project rolling log of session
+summaries, one entry per day, last 10 entries kept (count-based, not age-based).
+
+```
+/session-end          → write today's summary (manual, high quality)
+/session-end show     → print the last entry
+/session-end all      → print all entries (oldest → newest)
+```
+
+---
+
+## /session-end (no args) — write today's summary
+
+Review the current conversation and write today's entry to
+`.claude/session-log.md`. Use this before switching projects or closing
+Claude Code. The Stop hook (if configured) auto-generates a summary on
+exit, but `/session-end` produces better output — full session context,
+not transcript extraction.
+
+If an entry for today already exists it is **replaced**, not duplicated.
+After write, the log is rotated to keep the last 10 entries.
+
+### Entry format
+
+```markdown
+## YYYY-MM-DD
+
+### Що зробили
+- completed item
+
+### Поточний стан
+- current branch / open PR number
+- what is working / what is broken
+
+### Відкриті питання
+- unresolved question (omit section if none)
+
+### Наступні кроки
+- next item, in priority order
+```
+
+Rules: 10–20 bullets total · Ukrainian for content · English for code/files/identifiers · include PR number and branch in Поточний стан · omit Відкриті питання if none.
+
+### Write logic
+
+```python
+import re, os
+from datetime import date
+
+log = '.claude/session-log.md'
+today = str(date.today())
+max_keep = 10
+
+entry = """## {today}
+
+### Що зробили
+- ...
+
+### Поточний стан
+- ...
+
+### Наступні кроки
+- ...""".format(today=today).strip()
+
+# fill in entry content based on current session, then:
+
+if not os.path.exists(log):
+    open(log, 'w').write(entry + '\n')
+else:
+    content = open(log).read()
+    parts = re.split(r'(?m)(?=^## \d{4}-\d{2}-\d{2})', content)
+    entries = [p.strip() for p in parts if p.strip()]
+    today_idx = next((i for i, e in enumerate(entries) if e.startswith(f'## {today}')), -1)
+    if today_idx >= 0:
+        entries.pop(today_idx)
+        entries.append(entry)        # replace today, moved to end
+    else:
+        entries.append(entry)        # new day
+    entries = entries[-max_keep:]    # freshest write can never be trimmed away
+    open(log, 'w').write('\n\n'.join(entries) + '\n')
+```
+
+After writing, report:
+> "Session log updated — `.claude/session-log.md`, entry for {today}."
+
+---
+
+## /session-end show — print last entry
+
+```python
+import re
+
+try:
+    with open('.claude/session-log.md') as f:
+        parts = re.split(r'(?m)(?=^## \d{4}-\d{2}-\d{2})', f.read())
+    entries = [p.strip() for p in parts if p.strip()]
+    print(entries[-1] if entries else '(no entries)')
+except FileNotFoundError:
+    print('No session log found. Run `/session-end` to create one.')
+```
+
+---
+
+## /session-end all — print all entries
+
+```python
+import re
+
+try:
+    with open('.claude/session-log.md') as f:
+        parts = re.split(r'(?m)(?=^## \d{4}-\d{2}-\d{2})', f.read())
+    entries = [p.strip() for p in parts if p.strip()]
+    for e in entries:
+        print(e)
+        print()
+    if entries:
+        dates = [e.split('\n')[0].replace('## ', '') for e in entries]
+        print(f"{len(entries)} entries: {dates[0]} → {dates[-1]}")
+except FileNotFoundError:
+    print('No session log found.')
+```
+
+---
+
+## How the full system works
+
+```
+Session ends (exit / /exit)
+  └─ Stop hook: .claude/hooks/session-end.sh   (if configured)
+       ├─ Skip if /session-end ran within 2h (file mtime check)
+       ├─ Try agy -p  (Gemini Flash → Pro, cheapest first)
+       ├─ Try opencode run --format json  (available ollama/*:cloud models)
+       ├─ Fallback: raw transcript excerpt
+       └─ Rotates session-log.md to last 10 entries (count-based, no age filtering)
+
+Next session opens
+  └─ SessionStart hook: .claude/hooks/session-last.sh   (if configured)
+       ├─ Reads last ## YYYY-MM-DD entry from session-log.md
+       └─ Injects as additionalContext: "Previous session context (Xd Yh ago): ..."
+```
+
+The skill works standalone (without hooks) — you just run `/session-end`
+manually. The hooks add automation.
+
+**Log file**: `.claude/session-log.md` — add to `.gitignore`:
+```gitignore
+.claude/session-log.md
+```
+
+**Setup guide** (hooks + settings.local.json):
+Run `/generate-session-end` in the project — it installs hooks and writes
+`settings.local.json` automatically.
+
+**Troubleshooting** (if hooks are configured):
+```bash
+tail -30 ~/.cache/$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")")/hooks.log
+cat .claude/session-log.md
+```

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,98 +1,176 @@
 ---
 name: ship
-description: Full issue lifecycle — pick an issue, branch, implement, PR, Copilot review (one round), merge, close issue, return to main. One issue at a time.
+description: Implement a GitHub issue end-to-end — branch, code, tests, PR, /fix-review, merge, resolve. Without args, shows top 5 unblocked issues to select from. With issue number or title, ships that issue directly. One issue at a time.
 user-invocable: true
-argument-hint: "[issue-number|issue-title] — omit to pick from the top 5 open issues"
+argument-hint: "[issue-number | issue-title]"
 metadata:
-  version: "2.1"
-  author: frontend-claude
-  last_updated: "2026-03-22"
+  version: "3.0"
+  domain: workflow
+  scope: pr-lifecycle
+  debt-level: balanced
 ---
 
 # /ship
 
+Implement one GitHub issue from selection to merged PR, then present the next.
+
+```
+select issue → branch → implement → pre-PR review (parallel) → pre-flight → PR → /fix-review → merge → resolve → next
+```
+
 ## Rules
 
-- One issue at a time. Never work on two issues in parallel.
-- Only ship PRs created by Claude or explicitly named by the user. Never touch Dependabot or third-party PRs.
-- Branch protection is on — no direct pushes to `main`. Always go through a PR.
-- One round of Copilot comments only. After fixing, do not wait for re-review.
-- If Copilot has no comments (or only approved), merge immediately.
-- Always return to `main` and pull after merge before picking the next issue.
+- **One issue at a time.** Never work on multiple issues in parallel.
+- **Branch protection** — no direct pushes to `main`. Always use a PR.
+- Only ship PRs created by Claude or explicitly named by the user. Never touch Dependabot PRs (use the global `dependabot-reviewer` agent instead).
+- **Run `/fix-review` after PR creation.** Concurrent multi-model dispatch (`config.yaml`) then Claude arbiter. Address CONFIRM findings in one commit, then merge.
+- After merge: checkout main, pull, then present the next unblocked issue.
 
-## Steps
+---
 
-### 1. Pick issue
+## Step 0: Select issue
 
-Three entry points:
+**`/ship <number>`** — fetch that issue directly, skip menu.
 
-- **`/ship <number>`** — use that issue number directly.
-- **`/ship <title>`** — run `gh issue list --state open --search "<title>"`, pick the best match, confirm with the user.
-- **`/ship` (no argument)** — list the top 5 open, **unblocked** issues by priority:
+**`/ship <title>`** — search open issues for a title match, skip menu if unambiguous.
 
+**`/ship` (no args)** — list the top 5 open, unblocked issues sorted by priority:
+
+```bash
+gh issue list --repo valpere/vmm-rada-web-ui --state open \
+  --json number,title,labels \
+  --jq '[.[] | select(.labels | map(.name) | contains(["blocked"]) | not)]
+        | sort_by(
+            (.labels | map(.name) | map(
+              if . == "p0: critical" then 0
+              elif . == "p1: high" then 1
+              elif . == "p2: medium" then 2
+              else 3 end
+            ) | min) // 3
+          )
+        | .[:5]
+        | to_entries[]
+        | "\(.key + 1). #\(.value.number) \(.value.title) [\(.value.labels | map(.name) | join(", "))]"'
 ```
-Open issues (top 5):
 
-  1. [p3] gh#12  fix(api)      — Buffer partial SSE lines across chunks
-  2. [p3] gh#14  chore(dx)     — Add ASOL frontmatter to backend-sync agent
-  3. [p3] gh#15  refactor(app) — SSE event switch → named handler map
+If **all open issues are blocked**, say so and stop — do not show a menu.
 
-Select 1–3:
+Display as a numbered menu and wait for selection.
+
+---
+
+## Step 1: Read the issue
+
+```bash
+gh issue view <number> --repo valpere/vmm-rada-web-ui --json title,body,labels
 ```
 
-Exclude issues labelled `blocked` or noted as blocked in their body. If every open
-issue is blocked, say "All open issues are currently blocked" and stop — no selection.
+Read `## Summary` and `## Acceptance Criteria`. These define what done looks like.
 
-Wait for the user to select. Do not proceed until confirmed.
+---
 
-### 2. Branch
+## Step 2: Read affected files
+
+Read every file that will change. Do not guess — read them first.
+
+Typical candidates:
+- **State** — `src/App.jsx`
+- **API adapter** — `src/api.js`
+- **Components** — `src/components/Sidebar.jsx`, `ChatInterface.jsx`, `Stage1.jsx`, `Stage2.jsx`, `Stage3.jsx`
+- **Tests** — co-located `*.test.jsx` files (Vitest + Testing Library)
+- **Docs** — `docs/api-contract.md`, `docs/streaming.md`, `docs/architecture.md` if the change touches the backend contract
+
+---
+
+## Step 3: Resolve uncertainties
+
+Before touching any code, identify everything that is ambiguous or has more than one valid approach.
+
+**Look for:**
+- Naming mismatches — env var names, field names, or SSE event shapes that differ between the issue, `CLAUDE.md`, `docs/api-contract.md`, and existing code
+- Multiple valid implementation approaches with real trade-offs
+- Backend contract assumptions that may have drifted (this repo doesn't build against the Go backend in CI — verify against `docs/streaming.md` rather than assuming)
+
+**For each ambiguity, investigate first.** Read related files — `CLAUDE.md`, `docs/`, existing components — to find a ground truth. Many apparent ambiguities resolve silently from the codebase.
+
+**Then decide:**
+
+| Situation | Action |
+|-----------|--------|
+| One clear answer from docs/code | Resolve silently. Note the source. Proceed. |
+| Multiple valid options with real trade-offs | List them numbered. **Stop and wait for user selection.** |
+| No solution found — spec is genuinely incomplete | State what is missing. **Stop and ask for clarification.** |
+
+Do not branch until all uncertainties are resolved. A question answered before implementation costs nothing; a question discovered during `/fix-review` costs a round-trip.
+
+---
+
+## Step 4: Create branch and implement
 
 ```bash
 git checkout main && git pull
-git checkout -b <type>/<short-description>
+git checkout -b <type>/<slug>   # e.g. fix/stage3-error-ui, refactor/sse-handler-map
 ```
 
 Branch naming: `feat/…`, `fix/…`, `docs/…`, `refactor/…`, `chore/…`
 
-### 3. Implement
+Implement within the layer boundaries (see `.claude/context-essentials.md` — these
+are immutable):
 
-Read the issue. Make all necessary changes. Run lint after:
-
-```bash
-npm run lint   # must pass before continuing
+```
+App.jsx (state owner)
+  ↓ props only
+Components (pure UI, no fetch/api.js calls)
+  ↑
+src/api.js (SSE adapter — sole HTTP/SSE client)
 ```
 
-Commit with conventional format: `fix(scope): description` / `feat(scope): description`
+Commit with conventional format: `fix(scope): description` / `feat(scope): description`.
 
-### 4. Pre-PR review (parallel)
+---
 
-Before creating the PR, launch **security-reviewer** and **static-analysis** simultaneously in a single Agent tool call batch. Wait for both to complete.
+## Step 5: Pre-PR review (parallel)
+
+Before creating the PR, launch **security-reviewer** and **static-analysis**
+simultaneously in a single Agent tool call batch. Wait for both to complete.
 
 - **security-reviewer**: checks for XSS risks, injection, hardcoded secrets, insecure patterns
 - **static-analysis**: verifies lint passes and flags any cosmetic violations missed
 
-Address any CRITICAL or HIGH security findings and any remaining lint violations before continuing. LOW/MEDIUM security findings: note in the PR description.
+Address any CRITICAL or HIGH security findings and any remaining lint violations
+before continuing. LOW/MEDIUM security findings: note in the PR description.
 
-### 5. Pre-flight
+---
+
+## Step 6: Pre-flight
 
 ```bash
+npm run lint
+npm test
 git status                         # nothing uncommitted
 git log main..HEAD --oneline       # commits look right
 ```
 
-### 6. Create PR
+Fix any failures from your changes before proceeding. Note pre-existing failures separately.
 
-Include `Closes #N` in the body so GitHub closes the issue on merge.
+---
+
+## Step 7: Create PR
 
 ```bash
 git push -u origin <branch>
-gh pr create --title "<debt-emoji> <type>(<scope>): <title>" --body "$(cat <<'EOF'
-## Summary
-<bullet points from commits>
 
-Closes #N
+gh pr create \
+  --title "<debt-emoji> <type>(<scope>): <description>" \
+  --body "$(cat <<'EOF'
+## Summary
+<bullet points>
+
+Closes #<issue-number>
 
 ## Test plan
+- [ ] `npm run lint` passes
+- [ ] `npm test` passes
 - [ ] Dev server starts (`npm run dev`)
 - [ ] Feature works end-to-end with backend running
 - [ ] No console errors
@@ -102,44 +180,62 @@ EOF
 )"
 ```
 
-Debt emoji in title: `⚡` quick-fix · `⚖️` balanced · `🏗️` proper-refactor
+Debt emoji: `⚡` quick-fix · `⚖️` balanced · `🏗️` proper-refactor
 
-### 7. Wait for Copilot — check yourself
+---
 
-```bash
-gh pr view <number> --json reviews,statusCheckRollup
-```
+## Step 8: Run /fix-review
 
-Poll every ~30s (timeout 5 min). Do not ask the user — check the status yourself.
-If Copilot doesn't review within 5 minutes, proceed to merge anyway.
+Invoke `/fix-review <number>` — concurrent 3-model dispatch (`config.yaml`), vote
+tally, then Claude arbiter (CONFIRM / DISMISS / DEFER). Address all CONFIRM
+findings in one commit; push. `/fix-review` merges when no blockers remain.
 
-### 8. Address comments (if any)
+---
 
-One round only. Use the Code Review Pyramid to prioritise:
-- Layer 1 (Architecture) → Layer 2 (Correctness) → Layer 3 (Documentation)
-- Skip Layer 5 (Style) — automated by ESLint
+## Step 9: (handled by /fix-review)
 
-Fix all actionable Copilot comments, push, then proceed to merge without waiting for re-review.
+`/fix-review` posts a PR comment summarising the pass and merges once clean.
+No manual polling or comment-fetching needed.
 
-### 9. Merge
+---
+
+## Step 10: Merge
 
 ```bash
 gh pr merge <number> --squash --delete-branch
-```
-
-### 10. Return to main
-
-```bash
 git checkout main && git pull
 ```
 
-### 11. Report
+---
 
-Summarise: issue closed, PR number, what pre-PR review found (if anything), what Copilot flagged (if anything), what was fixed, merge commit.
+## Step 11: Resolve and report
+
+The `Closes #N` in the PR body auto-closes the issue on merge. Verify:
+
+```bash
+gh issue view <number> --repo valpere/vmm-rada-web-ui --json state,closed
+```
+
+If not closed automatically:
+```bash
+gh issue close <number> --repo valpere/vmm-rada-web-ui --comment "Resolved in PR #<pr-number>."
+```
+
+Report: issue closed, PR merged, what pre-PR review and `/fix-review` found and addressed, merge commit.
+
+---
+
+## Step 12: Present next issue
+
+Show the next unblocked issue from the queue (same query as Step 0, skip already-resolved).
+**Do not start implementing it** — wait for the user's command.
+
+---
 
 ## What NOT to do
 
+- Do not work on more than one issue at a time.
 - Do not bump version numbers or update changelogs unless explicitly asked.
-- Do not open follow-up issues unless a Copilot comment reveals a real bug outside the PR scope.
-- Do not ask the user to check Copilot — check it yourself.
-- Do not work on the next issue until the current one is merged and main is clean.
+- Do not open follow-up issues unless review reveals a real bug outside PR scope.
+- Do not skip `/fix-review` — it is the required review gate before merge.
+- Do not ask the user to check review status — check it yourself.

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # VMM Rada — frontend configuration
 # Copy to .env and fill in your values.
 #
-#   cp frontend/.env.example frontend/.env
-#   $EDITOR frontend/.env
+#   cp .env.example .env
+#   $EDITOR .env
 
 # ── API base URL ─────────────────────────────────────────────────────────────
 # URL of the backend API server.
@@ -11,3 +11,12 @@
 # or when serving the built frontend outside of the Vite dev server.
 # Default (when unset): relative URLs are used, which work with the proxy.
 # VITE_API_BASE=http://localhost:8001
+
+# ── fix-review / dreaming (Claude Code tooling) ──────────────────────────────
+# Ollama ignores the auth header, but a non-empty value is required to pass
+# the fix-review skill's key-presence check.
+# AI_PROVIDER_API_KEY=local-dev
+
+# ── aga2aga (agent-to-agent messaging with the vmm-rada backend repo) ───────
+# AGA2AGA_AGENT_NAME=vmm-rada-web-ui
+# AGA2AGA_API_KEY=local-dev

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-React 19 + Vite single-page application for **LLM Council** — a 3-stage deliberation system where multiple LLMs answer a question, peer-review each other anonymously, and a Chairman model synthesizes a final answer.
+React 19 + Vite single-page application for **VMM Rada** — a 3-stage deliberation system where multiple LLMs answer a question, peer-review each other anonymously, and a Chairman model synthesizes a final answer.
 
 The frontend communicates with a Go backend running on port 8001 via REST and Server-Sent Events (SSE). See `docs/api-contract.md` and `docs/streaming.md` for the API contract.
 
@@ -13,9 +13,8 @@ npm install       # install dependencies
 npm run dev       # dev server at http://localhost:5173
 npm run build     # production build
 npm run lint      # ESLint
+npm test          # Vitest
 ```
-
-There is no test suite.
 
 ## Architecture
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,20 @@ dist-ssr
 !.claude/plans/**
 !.claude/skills/
 !.claude/skills/**
-# Keep ephemeral/local files excluded:
+!.claude/hooks/
+!.claude/hooks/**
+!.claude/dreaming/
+!.claude/dreaming/**
+!.claude/context-essentials.md
+!.claude/settings.json
+# Keep ephemeral/local/per-machine files excluded:
 .claude/.onlooking-from-backend.md
 .claude/.onlooking-from-backend.md.lock
 .claude/settings.local.json
+.claude/sessions.db
+.claude/sessions.db-wal
+.claude/sessions.db-shm
+.claude/session-log.md
 
 # Editor directories and files
 .vscode/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,19 +12,22 @@ npm run lint       # ESLint
 npm run preview    # serve the production build locally
 ```
 
-**Skill setup (one-time, per machine):**
-```bash
-mkdir -p ~/.claude/skills
-for skill in .claude/skills/*/; do
-  [ -d "$skill" ] || continue
-  ln -sfn "$(pwd)/$skill" ~/.claude/skills/"$(basename "$skill")"
-done
-```
+Test suite: `npm test` (Vitest + Testing Library). Single file:
+`npx vitest run src/api.test.js`. Single test by name: `npx vitest run -t
+"<test name>"`. Watch mode: `npm run test:watch`.
 
-This registers all project skills in `.claude/skills/` as slash commands in Claude Code.
-Note: `.claude/` is excluded from git by the global gitignore (`.*`), so skill files live only on the local filesystem and must be set up per machine using the snippet above.
+`.claude/agents/`, `.claude/skills/`, `.claude/plans/`, `.claude/dreaming/`,
+and `.claude/context-essentials.md` are git-tracked (explicitly un-ignored
+in `.gitignore` — no manual symlink setup needed, they work on any clone).
+`.claude/settings.local.json` (session-recall/session-end hooks) and
+`.claude/agent-memory/` (created lazily on first agent write) stay
+per-machine and are gitignored.
 
-Test suite: `npm test` (Vitest + Testing Library).
+**One-time per-machine setup:** `/recall` (semantic session search) is a
+**user-level** skill (`~/.claude/skills/session-recall/`) — nothing to
+install here. It requires the `session-indexer` binary on `PATH`; if
+missing, `/recall` prints install instructions
+(`~/wrk/common/skills/session-recall/generate/SKILL.md`).
 
 ## Architecture
 
@@ -87,10 +90,15 @@ refactor/{description}        e.g. refactor/extract-sse-handler
 
 **Skills** (invoke with `/skill-name`):
 - `/backlog` — show top 5 backlog items or plan a specific task; reads affected files, writes a plan file, offers to create a GitHub issue
-- `/fix-review` — address Copilot PR comments (one round, Code Review Pyramid priority); does not merge
-- `/ship` — full PR lifecycle: lint → create PR → Copilot → fix → squash merge → checkout main
+- `/fix-review` — multi-model PR review (3 concurrent Ollama models + Claude arbiter, see `.claude/skills/fix-review/config.yaml`); merges when clean. Not Copilot-based.
+- `/ship` — full issue lifecycle: branch → implement → pre-PR review → PR → `/fix-review` → merge → resolve → next
 - `/find-bugs` — 5-phase security/bug audit of current branch changes; report-only
 - `/improve` — research-first critic for plans and designs; SHIP IT / IMPROVE IT / RETHINK IT / KILL IT verdict
+- `/apply-dreaming` — walk the latest weekly dreaming report, apply high-confidence findings
+- `/session-end` — write today's session summary to `.claude/session-log.md` (also auto-runs on session Stop; this is the higher-quality manual version)
+
+**Dependabot PRs** are handled by the global `dependabot-reviewer` agent
+(`~/.claude/agents/dependabot-reviewer.md`), not `/fix-review` or `/ship`.
 
 **Agents** (invoked via `Agent` tool):
 - `tech-lead` — architectural authority; reviews plans before implementation and code before merging; enforces SSE adapter boundary, App.jsx state model, and security rules
@@ -103,7 +111,16 @@ refactor/{description}        e.g. refactor/extract-sse-handler
 - `pm-issue-writer` — translates informal requests into RFC 2119-compliant GitHub issue drafts
 - `ci-build-agent` — GitHub Actions workflow creation and CI pipeline maintenance
 
-All agents have persistent memory in `.claude/agent-memory/<agent-name>/`.
+Agents get persistent memory in `.claude/agent-memory/<agent-name>/`, created
+lazily the first time an agent writes to it — the directory won't exist on
+a fresh clone.
+
+**Session recall & dreaming:** `/recall <query>` (user-level skill) searches
+past session transcripts semantically. `.claude/dreaming/` runs a weekly
+scheduled self-review (drift from `context-essentials.md`, recurring
+`/fix-review` themes, stale plans) — see `.claude/dreaming/README.md` for
+the systemd timer setup. Reports land in `.claude/dreaming/reports/`,
+applied via `/apply-dreaming`.
 
 ## Known gaps
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -18,7 +18,7 @@ Skills and agents are different invocation mechanisms for Claude. Skills run in 
 
 ## Skills
 
-All skills are invoked with `/skill-name`. They are defined in `.claude/skills/` and registered per-machine with the symlink setup in `CLAUDE.md`.
+All skills are invoked with `/skill-name`. They are defined in `.claude/skills/` and git-tracked — they work on any clone, no per-machine setup needed.
 
 ### `/backlog` — Plan before coding
 
@@ -50,28 +50,23 @@ All skills are invoked with `/skill-name`. They are defined in `.claude/skills/`
 2. Implement → `npm run lint`
 3. **Parallel pre-PR review:** launch `security-reviewer` + `static-analysis` simultaneously; address findings
 4. Push → create PR with `Closes #N` and debt emoji in title
-5. Poll for Copilot review (up to 5 min); address one round of comments using the Code Review Pyramid
+5. Run `/fix-review` — concurrent multi-model dispatch + arbiter; address findings
 6. Squash merge → `git checkout main && git pull`
 
 **Rules:**
 - One issue at a time
-- Only PRs created by Claude or explicitly named — never touch Dependabot PRs
-- One round of Copilot comments; do not loop on re-reviews
+- Only PRs created by Claude or explicitly named — never touch Dependabot PRs (use the `dependabot-reviewer` agent)
 
-### `/fix-review` — Address review comments
+### `/fix-review` — Multi-model review pipeline
 
-**When to use:** when a PR has Copilot comments to address, or when a Dependabot PR needs triage.
+**When to use:** after opening a PR, to run the multi-model review + arbiter pass before merging. Not for Dependabot PRs — use the `dependabot-reviewer` agent for those.
 
-**Copilot flow:**
-1. Fetch all Copilot comments
-2. Classify each by pyramid layer (see Code Review Pyramid below)
-3. Assign a ruling: CONFIRM / ESCALATE / DISMISS / DEFER
-4. Fix in priority order; run `npm run lint`; commit and push
-
-**Dependabot flow (no Copilot wait needed):**
-- **Patch bump** → merge immediately
-- **Minor bump** → check changelog for breaking changes; merge if clean
-- **Major bump** → write plan, create tracking issue via `/backlog`, comment PR, close PR without merging
+**Flow:**
+1. Dispatch the diff concurrently to 3 reviewer models (`config.yaml`)
+2. Tally findings by `file:line`, attach vote count (informational)
+3. Claude arbiter classifies each by pyramid layer (see Code Review Pyramid below), rules CONFIRM / ESCALATE / DISMISS / DEFER
+4. Fix CONFIRM findings in priority order; run `npm run lint` + `npm test`; commit and push
+5. Post PR comment with findings table; merge if no blockers remain
 
 ### `/find-bugs` — Security and bug audit
 
@@ -93,7 +88,10 @@ Backs its verdict with concrete, actionable findings and best-practice reference
 
 Agents are launched via the `Agent` tool (by Claude or skills). They run in isolated sub-conversations. Some are invoked proactively by other agents; all can be invoked by the human directly.
 
-All agents have persistent memory in `.claude/agent-memory/<agent-name>/`. They accumulate institutional knowledge across conversations.
+Agents get persistent memory in `.claude/agent-memory/<agent-name>/`, created
+lazily the first time an agent writes to it — the directory won't exist on a
+fresh clone. Once created, memory accumulates institutional knowledge across
+conversations.
 
 ### `tech-lead` — Architectural authority
 
@@ -158,7 +156,7 @@ Produces RFC 2119-compliant GitHub issue draft text (does not create the issue d
 
 **When invoked:** when a GitHub Actions workflow needs to be created or modified; when CI fails due to workflow configuration.
 
-Only modifies `.github/workflows/`. Uses `npm ci`, Node 20, concurrency cancellation. Should include a `npm test` step (Vitest suite exists as of the frontend/vmm-rada-monorepo sync).
+Only modifies `.github/workflows/`. Uses `npm ci`, Node 20, concurrency cancellation. Should include a `npm test` step (Vitest suite).
 
 ---
 
@@ -184,7 +182,7 @@ code-simplifier
     ↓ readability pass
 /ship (or manual PR)
     ↓ PR created
-Copilot review → /fix-review (one round)
+/fix-review (multi-model + arbiter)
     ↓
 squash merge → docs-maintainer (if architecture changed)
 ```
@@ -196,30 +194,22 @@ Human reports error/symptom
     ↓
 bug-fixer
     ↓ minimal fix, PR
-/fix-review (Copilot round if needed)
+/fix-review
     ↓
 squash merge
 ```
 
 ### Dependabot pipeline
 
-```
-Dependabot opens PR
-    ↓
-/fix-review (auto-detect Dependabot author)
-    ↓ patch
-merge immediately
-    ↓ minor
-check changelog → merge if clean
-    ↓ major
-write plan → /backlog → tracking issue → close PR
-```
+Handled by the global `dependabot-reviewer` agent (`~/.claude/agents/dependabot-reviewer.md`),
+not `/fix-review` or `/ship` — risk-based SemVer triage, separate from this
+repo's PR-quality pipeline.
 
 ---
 
 ## Code Review Pyramid
 
-Used by `/fix-review` (Copilot rulings) and informally by all agents when reviewing code. Fix from the bottom up.
+Used by `/fix-review`'s arbiter and informally by all agents when reviewing code. Fix from the bottom up.
 
 ```
         ▲
@@ -312,7 +302,10 @@ Closes #N
 
 ## Agent Memory System
 
-All agents maintain persistent memory in `.claude/agent-memory/<agent-name>/`. Memory files survive across conversations, giving agents institutional knowledge about user preferences, project decisions, and patterns to repeat or avoid.
+Agents maintain persistent memory in `.claude/agent-memory/<agent-name>/`
+(created lazily on first write). Memory files survive across conversations,
+giving agents institutional knowledge about user preferences, project
+decisions, and patterns to repeat or avoid.
 
 ### Memory types
 
@@ -349,8 +342,8 @@ The backend must be running before starting the dev server. CORS is configured o
 | Informal request → GitHub issue | `pm-issue-writer` agent → `/backlog` |
 | Implementing a GitHub issue | `/ship` or `code-generator` agent |
 | Bug reported with a stack trace | `bug-fixer` agent |
-| Dependabot PR open | `/fix-review` |
-| PR has Copilot comments | `/fix-review` |
+| Dependabot PR open | `dependabot-reviewer` agent |
+| PR ready for review | `/fix-review` |
 | Audit changed code for security | `security-reviewer` agent or `/find-bugs` |
 | Lint failing | `static-analysis` agent |
 | Plan seems risky / architectural | `tech-lead` agent or `/improve` |


### PR DESCRIPTION
## Summary
- Makes `.claude/agents`, `.claude/skills`, `.claude/dreaming`, and `.claude/context-essentials.md` git-tracked so they work on any clone without the old manual symlink setup
- Rewires `/fix-review` to the multi-model Ollama + Claude arbiter workflow and `/ship` to the full issue lifecycle
- Adds weekly dreaming self-review, session-recall/session-end hooks, and an eslint-fix PostToolUse hook

## Test plan
- [x] `git status` clean after commit, only intended paths staged
- [ ] `npm run lint` passes
- [ ] `/fix-review` multi-model round on this PR