### PR TITLE
fix(dx): pass agy prompt as arg, validate summary output, refresh sta…

### DIFF
--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -106,6 +106,16 @@ $EXCERPT"
 
 # --- LLM call helpers ---
 
+# is_valid_summary rejects anything that doesn't start with the expected
+# "## $TODAY" header — guards against a model ignoring the prompt and
+# returning generic chit-chat (observed: agy silently dropping the prompt
+# when passed via stdin, e.g. "I am currently running on Gemini 3.5
+# Flash..."). A non-empty result is not enough on its own; it must also
+# look like the summary we asked for, or the next tier should be tried.
+is_valid_summary() {
+  [[ "$1" == "## $TODAY"* ]]
+}
+
 try_agy() {
   local models=(
     "Gemini 3.5 Flash (Low)"
@@ -118,8 +128,12 @@ try_agy() {
   for model in "${models[@]}"; do
     echo "[$(date -Iseconds)] session-end: trying agy model: $model" >> "$LOG_FILE"
     local result
-    result=$(timeout 45 agy -p --model "$model" <<< "$1" 2>>"$LOG_FILE") && \
-      [[ -n "$result" ]] && { echo "$result"; return 0; }
+    # Prompt as a positional arg, not stdin — `agy -p` reads the prompt
+    # from its argument; piping via `<<<` leaves it unset and agy falls
+    # back to a generic interactive-style greeting instead of erroring.
+    result=$(timeout 45 agy -p "$1" --model "$model" 2>>"$LOG_FILE") && \
+      is_valid_summary "$result" && { echo "$result"; return 0; }
+    echo "[$(date -Iseconds)] session-end: agy model $model returned no usable summary" >> "$LOG_FILE"
   done
   return 1
 }
@@ -150,8 +164,8 @@ Rules: 10-20 bullets total, Ukrainian for content, English for code/file names."
 try_opencode() {
   local models=(
     "ollama/glm-5.2:cloud"
-    "ollama/kimi-k2.7-code:cloud"
-    "ollama/minimax-m3:cloud"
+    "ollama/kimi-k2.5:cloud"
+    "ollama/minimax-m2.5:cloud"
     "ollama/qwen3.5:cloud"
   )
   command -v opencode &>/dev/null || return 1
@@ -172,7 +186,8 @@ for line in sys.stdin:
             parts.append(obj['part']['text'])
     except: pass
 print(''.join(parts))
-") && [[ -n "$result" ]] && { echo "$result"; return 0; }
+") && is_valid_summary "$result" && { echo "$result"; return 0; }
+    echo "[$(date -Iseconds)] session-end: opencode model $model returned no usable summary" >> "$LOG_FILE"
   done
   return 1
 }


### PR DESCRIPTION
…le model names

agy -p reads its prompt from an argument, not stdin — piping via <<< left it unset and agy silently fell back to a generic interactive greeting instead of erroring, which a bare `[[ -n "$result" ]]` check couldn't catch. Add is_valid_summary to require the expected "## $TODAY" header before accepting a result from either agy or opencode. Also refreshes two opencode model names (kimi-k2.7-code, minimax-m3) that no longer resolve to kimi-k2.5 and minimax-m2.5.