### PR TITLE
⚡ task(config): add CI workflow — lint, test, build on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm test
+
+      - run: npm run build
+        env:
+          VITE_API_BASE: ${{ secrets.VITE_API_BASE }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` — this repo has never had CI; no PR has ever been validated by lint/test/build automation
- Pipeline: `npm ci` → `npm run lint` → `npm test` → `npm run build` (fail-fast)
- Follows `ci-build-agent.md`'s documented requirements (Best Practice #8, Pre-Delivery Self-Check) rather than its own inline template, which is missing the `npm test` step those sections otherwise mandate
- `VITE_API_BASE` secret intentionally left unset — this is a build-only CI check, no artifact is deployed

Closes #48

## Pre-PR review notes (security-reviewer)
- 0 CRITICAL/HIGH findings
- 🟡 MEDIUM: `VITE_API_BASE` gets inlined into the client bundle by Vite at build time (standard `VITE_*` behavior) — fine as a public base URL, but this secret must never be repurposed for anything sensitive if a deploy step is added later
- 🔵 LOW: actions pinned to version tags (`@v4`) rather than commit SHAs — acceptable for first-party GitHub actions
- 🔵 LOW: no explicit `permissions:` block (inherits default `GITHUB_TOKEN` scope) — could add `permissions: contents: read` as future hardening

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (38/38)
- [ ] CI runs on this PR and passes
- [ ] A PR with a deliberate lint error fails CI (verify separately post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)