### PR TITLE
docs: list /housekeeping and /self-learn in CLAUDE.md's Skills section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,8 @@ refactor/{description}        e.g. refactor/extract-sse-handler
 - `/apply-dreaming` — walk the latest weekly dreaming report, apply high-confidence findings
 - `/session-end` — write today's session summary to `.claude/session-log.md` (also auto-runs on session Stop; this is the higher-quality manual version)
 - `/doubt-driven-development` — subjects non-trivial decisions to a fresh-context adversarial review before they stand; in-flight, not a post-hoc PR verdict like `/fix-review`
+- `/housekeeping` — recurring repo-health check (stale branches, debug output, tracked secrets, framework version drift, CI coverage delta); read-only, pass/fail table
+- `/self-learn` — log mistakes/wins, auto-promote recurring patterns to hard rules in CLAUDE.md (behind explicit confirmation), run retrospectives
 
 **Dependabot PRs** are handled by the global `dependabot-reviewer` agent
 (`~/.claude/agents/dependabot-reviewer.md`), not `/fix-review` or `/ship`.


### PR DESCRIPTION
## Summary
- `/housekeeping` (#57) and `/self-learn` (#58) merged without a `CLAUDE.md` Skills-section entry — their issues' Acceptance Criteria didn't require it at the time
- Adds both, closing the discoverability gap now that the backlog's skill installs are all done

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (38/38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)