### PR TITLE
docs: add read-only-sandbox checklist bullet to doubt-driven-development

### DIFF
--- a/.claude/skills/doubt-driven-development/SKILL.md
+++ b/.claude/skills/doubt-driven-development/SKILL.md
@@ -250,3 +250,4 @@ After applying doubt-driven development:
 - [ ] In interactive mode, cross-model was **explicitly offered** to the user (regardless of artifact stakes) and the response was acknowledged in the output
 - [ ] In non-interactive mode, cross-model was skipped and the skip was announced
 - [ ] Any external CLI invocation was preceded by a PATH check, a working-binary test, syntax confirmation with the user, and explicit authorization to run
+- [ ] Any external CLI invocation used a read-only/plan-mode sandbox flag (e.g. `--sandbox read-only`, `--approval-mode plan`), not a full-write mode


### PR DESCRIPTION
## Summary
- PR #59's pre-PR security-reviewer flagged (LOW) that Step 3's "load-bearing" read-only sandbox requirement for external CLI invocations had no matching Verification checklist bullet — an agent could confirm PATH/version/syntax with the user and still omit the sandbox flag with nothing catching it
- Couldn't fix in #59 since that PR's Acceptance Criteria required byte-identity to the canonical source (`~/wrk/common/skills/doubt-driven-development/SKILL.md`)
- Fixed upstream first, then synced here to restore byte-identity

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (38/38)
- [x] `diff` against `~/wrk/common/skills/doubt-driven-development/SKILL.md` confirms byte-identity restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)