### PR TITLE
chore(session-end): retire minimax-m2.5 / kimi-k2.5 on Ollama Cloud

### DIFF
--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -164,8 +164,8 @@ Rules: 10-20 bullets total, Ukrainian for content, English for code/file names."
 try_opencode() {
   local models=(
     "ollama/glm-5.2:cloud"
-    "ollama/kimi-k2.5:cloud"
-    "ollama/minimax-m2.5:cloud"
+    "ollama/kimi-k2.6:cloud"
+    "ollama/minimax-m2.7:cloud"
     "ollama/qwen3.5:cloud"
   )
   command -v opencode &>/dev/null || return 1


### PR DESCRIPTION
## Summary
- Ollama is retiring `minimax-m2.5` and `kimi-k2.5` cloud models on 2026-07-31. Updates the `session-end.sh` Stop-hook's opencode fallback model list to their recommended replacements: `minimax-m2.7`, `kimi-k2.6`.

## Test plan
- [x] `bash -n` syntax check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)