### PR TITLE
chore: add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+.PHONY: help install dev build preview lint test test-watch ci clean
+
+help:
+	@echo "Frontend (vmm-rada-web-ui):"
+	@echo "  make install     npm install"
+	@echo "  make dev         start dev server (http://localhost:5173)"
+	@echo "  make build       production build to dist/"
+	@echo "  make preview     serve the production build locally"
+	@echo "  make lint        eslint ."
+	@echo "  make test        vitest run"
+	@echo "  make test-watch  vitest (watch mode)"
+	@echo "  make ci          npm ci + lint + test + build (mirrors .github/workflows/ci.yml)"
+	@echo "  make clean       remove dist/ and node_modules/"
+
+install:
+	npm install
+
+dev:
+	npm run dev
+
+build:
+	npm run build
+
+preview:
+	npm run preview
+
+lint:
+	npm run lint
+
+test:
+	npm test
+
+test-watch:
+	npm run test:watch
+
+ci:
+	npm ci
+	npm run lint
+	npm test
+	npm run build
+
+clean:
+	rm -rf dist node_modules


### PR DESCRIPTION
## Summary
- Adds a `Makefile` with thin wrappers around `package.json`'s existing npm scripts (install/dev/build/preview/lint/test/test-watch/clean)
- `make ci` mirrors `.github/workflows/ci.yml`'s exact pipeline order (`npm ci` → lint → test → build)
- Style mirrors `vmm-rada`'s (sibling backend repo) Makefile — `.PHONY` targets, `help` listed first

## Test plan
- [x] `make lint` runs `npm run lint`, passes
- [x] `make test` runs `npm test`, passes (38/38)
- [x] `make help` prints the target list correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)