### PR TITLE
docs: sync development-workflow.md skills/agents and add make commands

### DIFF
--- a/.claude/dreaming/reports/2026-W30.md
+++ b/.claude/dreaming/reports/2026-W30.md
@@ -1,0 +1,117 @@
+# vmm-rada-web-ui dreaming pass — 2026-W30
+
+Date: 2026-07-26
+Branch surveyed: `main` (clean, synced with `origin/main` @ `e420851`)
+Commits examined: 19 (since 2026-06-26); 9 lifetime commits touching `src/`
+PRs examined: 20 merged (12 authored, 8 Dependabot); review comments read on 10
+
+## TL;DR
+
+- **Backend has moved contract-relevant ground since the frontend docs were frozen on 2026-07-20** — a new `409 ErrConversationClosed` on both clarification endpoints (`vmm-rada@0aa5178`, 2026-07-25) that `src/api.js` collapses into a generic `Failed to send message`, and `RoleBased` promoted to a live opt-in strategy (`vmm-rada@e066bc8`) while the frontend still renders it as a stub. Highest-impact item this pass.
+- **`/fix-review` signal-to-noise has collapsed: 15 findings across 7 PRs, 1 confirmed (6.7%).** Every recent PR is `.claude/` markdown, and the reviewer models keep inventing project facts (TypeScript files, missing test suite, wrong Vite version) they could have checked. Cheap fix: feed the arbiter a project-facts preamble.
+- **Docs-discipline drift the rule was written to prevent:** PR #63's Makefile and the three skills installed 2026-07-20 landed in `CLAUDE.md` but never in `docs/development-workflow.md`.
+- **Zero open issues, zero product work in ~4 months.** All 12 authored PRs since 2026-07-19 are tooling. The one documented product gap (no strategy picker) has never been filed.
+
+## 1. Context-essentials drift
+
+**Rules 1–4 (architecture, immutable) — all clean.** `high` confidence.
+- No `fetch(` and no `api.js` import under `src/components/` (grep, 0 hits).
+- No `setCurrent*` writes outside `App.jsx` (grep, 0 hits).
+- No `dangerouslySetInnerHTML` / `innerHTML` anywhere in `src/` (grep, 0 hits). `src/components/Markdown.jsx:7` is the single renderer, `react-markdown` + `rehype-highlight`, no `rehype-raw`.
+- No `.ts`/`.tsx` in `src/`; no competing markdown renderer in `package.json`.
+- `--no-verify`: only literal hits are the anti-pattern seeds in `c12d85a`, not usage.
+
+**Docs discipline — "Update `CLAUDE.md` and `docs/*.md` together" — violated twice.** Severity: medium. Confidence: `high`.
+- Evidence: `e420851` (PR #63) added `Makefile` with 10 targets; `CLAUDE.md`'s Commands section still lists only raw `npm run …` — grep for `Makefile|make ` across `CLAUDE.md` + `docs/` returns nothing but an unrelated prose hit at `docs/development-workflow.md:235`.
+- Evidence: `f3c073a`, `c12d85a`, `2492b94`, `75be50b` installed `/housekeeping`, `/self-learn`, `/doubt-driven-development` and the `test-generator` agent. `f1936f6` (PR #60) patched `CLAUDE.md` only. `docs/development-workflow.md` §Skills (lines 19–86) still lists exactly five skills — `/backlog`, `/ship`, `/fix-review`, `/find-bugs`, `/improve` — and §Agents (87–162) omits `test-generator`.
+- Suggest: one `docs:` PR syncing `development-workflow.md` §Skills/§Agents + a `make` line in `CLAUDE.md`. This is `docs-maintainer`'s exact remit and it was not invoked on any of those five PRs.
+
+**Workflow gate — `/fix-review` before merge — skipped on 3 PRs.** Severity: medium. Confidence: `medium` (absence of a posted comment is strong but not conclusive evidence the pass never ran; `post_summary_to_pr: true` in `config.yaml:35` means a run should have posted).
+- Evidence: PRs #47, #54, #62 carry no `/fix-review` summary comment. #47 (`809d055`) is the **largest `src/` diff in the repo's history** — the whole monorepo→standalone frontend extraction — and is the one PR where the four Layer 1 rules actually had surface to be violated.
+- Suggest: no retroactive action; note as precedent. If `/ship` is the intended path, its gate is not enforced for manually-driven PRs.
+
+**Branch naming — one violation.** Severity: low. Confidence: `high`.
+- Evidence: `origin/fix-ollama-model-retirement` (PR #62) — missing the `fix/` prefix required by `CLAUDE.md` §Workflow and `docs/development-workflow.md:250-258`.
+- Related inconsistency: `CLAUDE.md` lists four branch prefixes (`feat/fix/docs/refactor`); `docs/development-workflow.md:257` also lists `chore/`, which is what 4 of the last 8 branches actually used. `627ede7` used commit type `task(config):`, absent from both docs' Conventional Commits lists.
+- Suggest: promote `chore/` into `CLAUDE.md`, or drop the branch table from `CLAUDE.md` and point at `development-workflow.md` as the single source.
+
+## 2. Recurring `/fix-review` themes
+
+Tally across the 7 PRs with a posted summary (#53, #55, #56, #57, #58, #59, #63): **15 findings, 1 CONFIRMED, 14 DISMISSED, 0 deferred.**
+
+- **"Reviewer model asserts a project fact it did not verify"** — n=6 across PRs [#53 ×2, #57 ×1, #59 ×2, #58 ×1]. Confidence: `high`.
+  - `.claude/agents/ci-build-agent.md:33` — "project has no test suite" (PR #53); `package.json:14` defines `vitest run`, 38/38 pass.
+  - `.claude/agents/tech-lead.md:6` — "Vite 7→8 possibly unverified" (PR #53); `package.json:38` pins `^8.1.0`.
+  - `housekeeping/SKILL.md:56` — "console.log grep misses `.ts`/`.tsx`" (PR #57); TypeScript is banned project-wide.
+  - `doubt-driven-development/SKILL.md:45/68` — "future date 2026-07-07" (PR #59, 2/3 votes); it was 13 days past.
+  - Suggest: prepend a short immutable **project-facts block** to the reviewer prompt (plain JS / no TS, Vitest present, Vite 8 + React 19, current date, `.claude/` files are instructions not runtime code). Cheapest lever available — it would have suppressed 6 of 14 dismissals without touching arbiter logic. Owner: `.claude/skills/fix-review/`.
+
+- **"Reviewer treats `.claude/**/*.md` as production code"** — n≈8, i.e. effectively every finding in [#57, #58, #59]. Confidence: `high`.
+  - Arbiter wrote the same sentence verbatim on five PRs: *"diff is …markdown only (no `src/` changes) — none of the four Layer 1 immutable rules apply."*
+  - Suggest: a diff-shape pre-gate — if the diff touches no `src/`, run one reviewer instead of three. Three cloud models × zero yield is the current steady state.
+
+- **The single CONFIRMED finding was the one about `src/` semantics** — `.claude/agents/test-generator.md:41` (PR #56, 1/3 votes): XSS regression guidance asserted via raw `container.innerHTML` string match; changed to `querySelector('script') === null`, fixed in `4a02051`. Confidence: `high`.
+  - Suggest: worth a line in `context-essentials.md` §Banned patterns — *"XSS assertions go through `querySelector`, never `innerHTML` string matching"* — since rule 4 is the rule most likely to be regression-tested wrongly. This is the only genuinely durable lesson the whole review corpus produced.
+
+> [planned 2026-07-26: issue #71 (task(dx): add XSS assertion rule to context-essentials banned patterns); awaiting /backlog → Tech Lead → /ship]
+
+- **`gh pr diff` returned an `rtk`-compacted summary instead of a real diff** (PR #58 arbiter note, worked around via `git diff main...<branch>`). n=1, but it silently degrades review input. Confidence: `medium`.
+  - Suggest: make `git diff main...HEAD` the primary source in the skill, not the fallback.
+
+## 3. Stale plans
+
+- **None.** `.claude/plans/` contains only `README.md` (the schema doc, correctly permanent). All five plans from 2026-07-20 were promoted to issues #48–#52 and deleted per protocol — `session-log.md:4` records it, and issues #48–#52 are all CLOSED. Clean.
+
+## 4. Agent-memory health
+
+- **`.claude/agent-memory/` does not exist.** Ten agents defined in `.claude/agents/`, none has ever written a memory. `CLAUDE.md` and `docs/development-workflow.md:303-307` both describe it as lazily created — so this is expected-but-unexercised, not broken.
+- No stale memories, no contradictions, no cross-agent duplicates to report. Confidence: `high`.
+- Worth noting for contrast: the backend repo *does* use this (`vmm-rada@b4816a8`, "refresh stale agent-memory per W29 pass"). If agents here are producing nothing durable across ~12 PRs, either the pipeline isn't routing through them or the memory affordance is dead weight.
+
+## 5. Skill / agent inventory
+
+**Installed skills (11):** `_lib`, `apply-dreaming`, `backlog`, `doubt-driven-development`, `find-bugs`, `fix-review`, `housekeeping`, `improve`, `self-learn`, `session-end`, `ship`.
+
+- **`/doubt-driven-development` — installed, documented, wired into nothing.** Confidence: `high`. Grep for it in `ship/SKILL.md`, `backlog/SKILL.md`, `context-essentials.md`, `docs/development-workflow.md`: zero hits. It appears only in `CLAUDE.md`'s skill list and in `session-log.md` as an install task. Its whole value is being invoked *in-flight*; nothing invokes it. Suggest: add it to the `context-essentials.md` workflow gate line, or accept it as opt-in-by-memory and say so.
+
+> [planned 2026-07-26: issue #72 (task(dx): wire /doubt-driven-development into the workflow gate); awaiting /backlog → Tech Lead → /ship]
+- **`/housekeeping` was installed 2026-07-20 and appears never to have been run** — its check #1 is stale branches, and 7 merged remote branches plus 2 local ones are still sitting there (below). Confidence: `medium`.
+- **`/find-bugs` and `/improve`: no usage evidence** in `session-log.md` or any PR comment. Both predate the current tooling wave. Not obsolete — but `/find-bugs` (5-phase audit of branch changes) overlaps the `security-reviewer` agent and `/fix-review`'s Layer 2 pass substantially. Suggest: pick one entry point for pre-PR bug hunting; three is why none gets used.
+- **`tech-lead.md:149` cites a `/plan` skill that does not exist** — the pipeline line reads `/plan skill → Tech Lead (YOU) → …`; the actual skill is `/backlog`. Severity: low, but it's the architectural authority's own pipeline diagram. Confidence: `high`.
+- **Agent overlap:** `code-simplifier` (project) vs. the global `/simplify` skill; `security-reviewer` (project agent) vs. `/find-bugs` (project skill) vs. the global `/security-review`. No conflict observed in practice, mostly because none of them ran this period.
+- **Stale branches** (`git branch -a`): `origin/chore/add-makefile`, `origin/chore/doubt-driven-development-skill`, `origin/chore/housekeeping-skill`, `origin/chore/self-learn-skill`, `origin/docs/doubt-driven-development-sandbox-checklist`, `origin/docs/skills-list-gaps`, `origin/fix-ollama-model-retirement` — all merged, none deleted. Plus local `feat/sync-frontend-from-vmm-rada-monorepo` (2026-07-19) and `fix-ollama-model-retirement` (2026-07-22). Suggest: enable auto-delete-branch-on-merge in repo settings; it makes `/housekeeping` check #1 permanently green instead of permanently ignored.
+- **Model config is consistent** — `fix-review/config.yaml:14-16` (`qwen3.5:cloud`, `minimax-m2.7:cloud`, `gemma4:31b-cloud`) and `session-end.sh:165-170` (`glm-5.2`, `kimi-k2.6`, `minimax-m2.7`, `qwen3.5`) both post-date the 2026-07-31 Ollama retirement of `minimax-m2.5`/`kimi-k2.5` (PR #62, mirrored backend-side in `vmm-rada@96f6af7`). No action.
+
+## 6. Backend contract drift
+
+Frontend `docs/api-contract.md` and `docs/streaming.md` were both last touched `809d055` (2026-07-20 12:12). The backend has merged **9 PRs since**, three of them contract-relevant. This repo builds against no backend in CI, so nothing catches it.
+
+- **`409 ErrConversationClosed` on clarification submissions — unhandled and undocumented.** Severity: **high**. Confidence: `high`.
+  - Evidence: `vmm-rada@0aa5178` (2026-07-25, PR #310) — "reject round-N clarification answers on a closed conversation"; adds `ErrConversationClosed` → 409 to *both* `sendMessage` and `sendMessageStream` round-N branches (round-1 already returned 409 before this).
+  - Frontend side: grep for `409|closed|Closed` across `docs/api-contract.md`, `src/api.js`, `src/App.jsx` → **0 hits**. `src/api.js:130-132` maps every non-2xx to `throw new Error('Failed to send message')`. A user answering Stage 0 questions on a closed conversation gets an indistinguishable generic failure.
+  - Suggest: file it. Surface 409 as a distinct, actionable state in `App.jsx`'s `error` field, and document the code in `docs/api-contract.md`.
+
+> [planned 2026-07-26: issue #70 (bug/api/ui: handle 409 ErrConversationClosed on clarification endpoints); awaiting /backlog → Tech Lead → /ship]
+- **`RoleBased` is now a live strategy; the frontend renders a stub.** Severity: medium. Confidence: `high`.
+  - Evidence: `vmm-rada@e066bc8` (2026-07-21, PR #303) registers `role-based` with `ROLE_BASED_MODELS` / `ROLE_BASED_CHAIRMAN_MODEL`, fixed `DefaultRoles` (Generator/Critic/Verifier/Simplifier), `QuorumMin = len(DefaultRoles)`. Previously unreachable in production.
+  - Frontend: `docs/streaming.md:197` maps `role_stub` → `[]` data, and `src/components/Stage2.jsx:631` is `RoleStubView`, "a minimal placeholder." The docs are *accurate*, but the strategy went from unreachable to deployable and Stage 2 shows a placeholder if anyone sets `DEFAULT_RADA_TYPE=role-based`.
+  - Suggest: confirm whether the backend now emits richer role payload; if so, `RoleStubView` needs a real view. At minimum, mark it `NOT YET WIRED:` per the docs-discipline rule.
+- **Golden-file contract tests + `docs/api.md` corrections** — `vmm-rada@18ef804` (PR #309) and `cd5fb5e` (per-endpoint error-reference column, PR #311). Confidence: `medium` on impact; I did not diff the backend's `docs/api.md` against this repo's `docs/api-contract.md` field by field.
+  - Suggest: a `docs-maintainer` pass diffing the two, now that the backend has golden files to diff *against*. The backend's new golden fixtures are the closest thing to a machine-checkable contract this pair has ever had — worth considering as a CI input here.
+- Context: `vmm-rada@48ae260` (2026-07-20) removed the deprecated `frontend/` from the monorepo. The split is complete; from here the two repos drift unless something checks. Nothing checks.
+
+## 7. Patterns I noticed
+
+- **The tooling has outgrown the product.** 11 skills, 10 agents, 4 hooks, dreaming, session-recall, self-learn, CI, a Makefile — and 9 lifetime commits to `src/`, the last of which was a file move. Every one of the 12 authored PRs since 2026-07-19 is `chore(dx)`, `docs`, or `task(config)`. The four Layer 1 immutable rules are perfectly observed, largely because almost no code has been written since they were written.
+- **Zero open GitHub issues.** Issues #48–#52 all closed 2026-07-20; nothing filed since. `CLAUDE.md` §Known gaps documents the strategy picker — `src/App.jsx:300` hardcodes `council_type: 'default'`, and `deriveStage2Kind` + the seven-way `Stage2.jsx` dispatcher are already built to receive it. It has never been an issue. It's the highest-value, lowest-risk product work available and the backlog is otherwise empty.
+- **Test coverage is concentrated where the risk isn't.** 38 tests across `App.test.jsx`, `api.test.js`, `Stage2.test.jsx`. No tests for `Stage0`, `Stage1`, `Stage3`, `Sidebar`, `ChatInterface`, `Markdown`, `EmptyState`, or `utils.js`. `Markdown.jsx` is the enforcement point for immutable rule 4 and has no test asserting that raw HTML doesn't render — the exact gap PR #56's confirmed finding was about. `test-generator` was built for this and has not been invoked once since.
+- **CI pins `node-version: '20'`** (`.github/workflows/ci.yml:20`) against `engines: >=20.19.0`. Functional today, but Node 20 is past EOL and the backend already bumped `actions/setup-node` to v7 (`vmm-rada@28d18bf`). Low severity, cheap to bump to 22.
+- **`/apply-dreaming` has existed with nothing to apply.** `.claude/dreaming/reports/` was empty before this run — `.dreaming.log` starts `2026-07-26T09:26:17`. This is the first report; the loop has never closed once.
+
+## 8. What I couldn't tell (need manual review)
+
+- **Whether `/fix-review` actually ran on PRs #47, #54, #62.** I inferred from absent comments plus `post_summary_to_pr: true`. A local run log would settle it.
+- **Whether the 409 gap is reachable in the deployed UI.** Depends on whether a conversation can be closed while a Stage 0 clarification is pending — that's backend state-machine territory I did not trace.
+- **Whether `RoleBased`'s SSE payload changed shape** in `vmm-rada@e066bc8`. I read the commit message and diffstat, not the strategy's emit path. If `data` is still `[]`, `docs/streaming.md:197` remains correct and only the view is thin.
+- **Field-level parity between backend `docs/api.md` and frontend `docs/api-contract.md`** after PRs #309/#311. Needs a real side-by-side.
+- **Whether `/find-bugs` and `/improve` are deliberately-held tools or dead weight.** No usage signal either way in the transcripts I can see from here; `/recall` over older sessions would answer it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,16 @@ npm run lint       # ESLint
 npm run preview    # serve the production build locally
 ```
 
+Or use `make`:
+```
+make install       # npm install
+make dev           # dev server at http://localhost:5173
+make build         # production build
+make lint          # ESLint
+make test          # vitest run
+make ci            # npm ci + lint + test + build
+```
+
 Test suite: `npm test` (Vitest + Testing Library). Single file:
 `npx vitest run src/api.test.js`. Single test by name: `npx vitest run -t
 "<test name>"`. Watch mode: `npm run test:watch`.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -82,6 +82,36 @@ Runs a 5-phase analysis: architecture violations, correctness issues, null-handl
 
 Backs its verdict with concrete, actionable findings and best-practice references.
 
+### `/apply-dreaming` — Apply weekly dreaming report
+
+**When to use:** Monday morning after the Sunday dreaming cron run produces a fresh report (`.claude/dreaming/reports/YYYY-W##.md`).
+
+Walks each finding interactively, routes load-bearing items through `/backlog` + Tech Lead, and leaves audit-trail annotations on the report.
+
+### `/housekeeping` — Repo health check
+
+**When to use:** any time for a hygiene snapshot.
+
+Read-only pass/fail table covering: stale branches, debug output in source, tracked `.env`/backup files, TODO/FIXME count, framework version drift in docs, and CI coverage delta (when wired).
+
+### `/self-learn` — Mistake/win logging
+
+**When to use:** after any significant task when something went wrong or something worked well.
+
+Logs mistakes/wins to `_patterns/*.jsonl`; auto-promotes recurring patterns to hard rules in `CLAUDE.md` (behind explicit user confirmation); runs retrospectives.
+
+### `/doubt-driven-development` — In-flight adversarial review
+
+**When to use:** for non-trivial decisions before they stand — architectural calls, irreversible operations, or any time a confident answer is cheaper to verify now than to debug later.
+
+Spawns a fresh-context reviewer biased to disprove, not approve. Complements `/fix-review`, which is a post-hoc verdict.
+
+### `/session-end` — Write session summary
+
+**When to use:** manually, or let it auto-run on session Stop.
+
+Writes a summary to `.claude/session-log.md`.
+
 ---
 
 ## Agents
@@ -157,6 +187,12 @@ Produces RFC 2119-compliant GitHub issue draft text (does not create the issue d
 **When invoked:** when a GitHub Actions workflow needs to be created or modified; when CI fails due to workflow configuration.
 
 Only modifies `.github/workflows/`. Uses `npm ci`, Node 20, concurrency cancellation. Should include a `npm test` step (Vitest suite).
+
+### `test-generator` — Generate colocated tests
+
+**When invoked:** when new JS/JSX source (components or utilities) is written or modified and needs a corresponding Vitest test file.
+
+Produces a colocated `*.test.jsx`/`*.test.js` following the repo's existing conventions, mocks `src/api.js`, and never hits the real network.
 
 ---
 
@@ -267,6 +303,7 @@ feat(scope): short description
 docs(scope): short description
 refactor(scope): short description
 chore(scope): short description
+task(scope): short description
 ```
 
 ### PR titles


### PR DESCRIPTION
## Summary
- Updates `docs/development-workflow.md` §Skills to include all 11 installed skills (`/apply-dreaming`, `/housekeeping`, `/self-learn`, `/doubt-driven-development`, `/session-end`) and adds `test-generator` to §Agents
- Adds `task(scope):` to the Conventional Commits list, matching actual usage (e.g. `task(config): add CI workflow`)
- Adds a `make ...` block to `CLAUDE.md` §Commands so the Makefile (PR #63) is discoverable alongside raw npm commands
- Includes the annotated 2026-W30 dreaming report as the apply-dreaming audit trail for items triaged this session

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (38/38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)