### PR TITLE
⚡ chore(config): bump package.json engines.node to match CI (>=22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Server-Sent Events deliberation stream.
 
 ## Prerequisites
 
-- Node.js ≥20.19
+- Node.js ≥22
 - The Go backend running on port 8001 (see
   [`vmm-rada`](https://github.com/valpere/vmm-rada))
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -186,7 +186,7 @@ Produces RFC 2119-compliant GitHub issue draft text (does not create the issue d
 
 **When invoked:** when a GitHub Actions workflow needs to be created or modified; when CI fails due to workflow configuration.
 
-Only modifies `.github/workflows/`. Uses `npm ci`, Node 20, concurrency cancellation. Should include a `npm test` step (Vitest suite).
+Only modifies `.github/workflows/`. Uses `npm ci`, Node 22, concurrency cancellation. Should include a `npm test` step (Vitest suite).
 
 ### `test-generator` — Generate colocated tests
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- `package.json`: `engines.node` bumped from `>=20.19.0` to `>=22` — CI (`.github/workflows/ci.yml`) has run Node 22 since PR #75, so the declared minimum was stale.
- `README.md`: prerequisites line synced to `Node.js ≥22`.
- `docs/development-workflow.md`: `ci-build-agent` doc reference synced from "Node 20" to "Node 22".

Surfaced while evaluating Dependabot PR #66 (`@testing-library/jest-dom` 7.0.0, requires Node 22+) — without an accurate `engines` field there was no way to tell from `package.json` alone whether adopting it was viable.

Closes #85

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (44/44)
- [ ] Dev server starts (`npm run dev`)
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)