### PR TITLE
⚖️ feat(stage2): implement RoleStubView as RoleBased view

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -206,6 +206,13 @@ content lives in the strategy-specific `metadata` field, not per-reviewer.
 An unrecognised `kind` renders via a fallback view
 (`Stage 2 — kind: <X> (view not implemented yet)`) rather than crashing.
 
+**`role_stub` is the one exception to "content lives in `metadata`."** RoleBased
+skips Stage 2 entirely — there is no strategy-specific metadata to show. The
+frontend's `RoleView` instead re-displays `stage1` (already present on the
+message) inside the Stage 2 slot, using each result's `label` directly as the
+role name (Generator/Critic/Verifier/Simplifier) — no `label_to_model` lookup,
+since role names aren't anonymised the way PeerReview's labels are.
+
 The frontend UI does not currently expose strategy selection — it always
 sends `council_type: "default"`. Which strategy that resolves to (and thus
 which `kind` you'll actually see) is decided by backend configuration. See

--- a/src/components/Stage2.css
+++ b/src/components/Stage2.css
@@ -494,6 +494,55 @@
   overflow: hidden;
 }
 
+/* Role view (RoleBased strategy) — one row per role, labeled by role name */
+
+.role-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.role-row {
+  padding: 10px 12px;
+  background: var(--bg-base);
+  border-radius: var(--radius-sm);
+  border-left: 3px solid var(--accent);
+}
+
+.role-row-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+
+.role-row-label {
+  font-family: monospace;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.role-row-model {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: monospace;
+}
+
+.role-row-content {
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.role-row-content.collapsed {
+  max-height: 4em;
+  overflow: hidden;
+}
+
 /* Delphi view (Delphi strategy) — per-round rating timeline */
 
 .delphi-timeline {

--- a/src/components/Stage2.jsx
+++ b/src/components/Stage2.jsx
@@ -628,27 +628,71 @@ function DelphiView({ delphi, isLoading }) {
   );
 }
 
-// RoleStubView renders a minimal placeholder for the RoleBased strategy,
-// where Stage 2 has no peer-ranking content (roles are complementary).
-function RoleStubView({ isLoading }) {
-  if (isLoading) {
+// RoleView renders the RoleBased strategy's Stage 2 slot. RoleBased has no
+// peer-ranking round (backend: internal/council/rolebased.go runRoleBased —
+// "Stage 2 is skipped; a minimal Stage2CompleteData event is emitted for SSE
+// compatibility"), so there is no strategy-specific metadata to show here.
+// The per-role content lives entirely in `stage1`, where `label` is the role
+// name (Generator/Critic/Verifier/Simplifier) rather than an anonymised
+// "Response A" — no de-anonymisation lookup needed, unlike PeerRankingView.
+// Re-displaying stage1 content inside the Stage 2 slot mirrors MoaView's
+// "Layer 1 — Proposers" panel, which does the same for MixtureOfAgents.
+function RoleRow({ result }) {
+  const [expanded, setExpanded] = useState(false);
+  const longText = (result?.content ?? '').length > REPRESENTATIVE_TRUNCATE_THRESHOLD;
+  return (
+    <div className="role-row">
+      <div className="role-row-header">
+        <span className="role-row-label">{result.label}</span>
+        <span className="role-row-model">{modelShortName(result.model)}</span>
+      </div>
+      <div className={`role-row-content markdown-content${longText && !expanded ? ' collapsed' : ''}`}>
+        <Markdown>{result.content}</Markdown>
+      </div>
+      {longText && (
+        <button
+          type="button"
+          className="vote-expand-btn"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+        >
+          {expanded ? 'Show less' : 'Show full answer'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function RoleView({ stage1, isLoading }) {
+  const roles = Array.isArray(stage1) ? stage1 : [];
+
+  if (isLoading && roles.length === 0) {
     return (
       <div className="stage stage2">
         <div className="stage-accordion" aria-disabled="true">
           <span className="stage-accordion-label">
             <span className="spinner-sm" />
-            Stage 2…
+            Roles working…
           </span>
         </div>
       </div>
     );
   }
+  if (roles.length === 0) return null;
+
   return (
     <div className="stage stage2">
       <div className="stage-accordion" aria-disabled="true">
         <span className="stage-accordion-label">
-          Stage 2: roles are complementary — no peer ranking.
+          Stage 2: Role Perspectives ({roles.length} role{roles.length !== 1 ? 's' : ''})
         </span>
+      </div>
+      <div className="stage-body">
+        <div className="role-list">
+          {roles.map((r, i) => (
+            <RoleRow key={`${r?.label ?? i}-${i}`} result={r} />
+          ))}
+        </div>
       </div>
     </div>
   );
@@ -706,7 +750,7 @@ export default function Stage2({
         />
       );
     case 'role_stub':
-      return <RoleStubView isLoading={isLoading} />;
+      return <RoleView stage1={stage1} isLoading={isLoading} />;
     case 'vote_tally':
       return <VoteTallyView voteTally={voteTally} isLoading={isLoading} />;
     case 'rank_refine':

--- a/src/components/Stage2.test.jsx
+++ b/src/components/Stage2.test.jsx
@@ -1,5 +1,5 @@
-// Tests for Stage2.jsx — the dispatcher routes by `kind` to one of three
-// sub-renderers (PeerRankingView, RoleStubView, UnknownKindView). These tests
+// Tests for Stage2.jsx — the dispatcher routes by `kind` to one of several
+// sub-renderers (PeerRankingView, RoleView, UnknownKindView, ...). These tests
 // drive each branch without mounting the rest of App.
 
 import { render, screen } from '@testing-library/react';
@@ -25,14 +25,6 @@ describe('Stage2 dispatcher', () => {
     // Peer-ranking view renders the strong-consensus pill.
     expect(screen.getByText(/Stage 2: Peer Rankings/i)).toBeInTheDocument();
     expect(screen.getByText(/W=0.80/i)).toBeInTheDocument();
-  });
-
-  it('routes kind="role_stub" to the role-stub view', () => {
-    render(<Stage2 kind="role_stub" isLoading={false} />);
-    expect(
-      screen.getByText(/roles are complementary — no peer ranking/i),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/Stage 2: Peer Rankings/i)).not.toBeInTheDocument();
   });
 
   it('routes an unknown kind to the unknown-kind view, surfacing the kind name', () => {
@@ -416,6 +408,61 @@ describe('Stage2 dispatcher', () => {
           kind="moa_aggregator"
           moaAggregator={aggregator}
           stage1={[{ label: 'Response A', content: 'short' }]}
+          isLoading={false}
+        />,
+      );
+      expect(screen.getByRole('button', { name: /Show full answer/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('RoleView (kind="role_stub")', () => {
+    const fourRoles = [
+      { label: 'Generator', model: 'openai/gpt-4o', content: 'generator answer' },
+      { label: 'Critic', model: 'anthropic/claude-sonnet-4-5', content: 'critic answer' },
+      { label: 'Verifier', model: 'openai/gpt-4o', content: 'verifier answer' },
+      { label: 'Simplifier', model: 'anthropic/claude-sonnet-4-5', content: 'simplifier answer' },
+    ];
+
+    it('renders one row per role with role name, model, and content', () => {
+      render(<Stage2 kind="role_stub" stage1={fourRoles} isLoading={false} />);
+      expect(screen.getByText(/Stage 2: Role Perspectives \(4 roles\)/i)).toBeInTheDocument();
+      for (const role of ['Generator', 'Critic', 'Verifier', 'Simplifier']) {
+        expect(screen.getByText(role)).toBeInTheDocument();
+      }
+      for (const answer of ['generator answer', 'critic answer', 'verifier answer', 'simplifier answer']) {
+        expect(screen.getByText(answer)).toBeInTheDocument();
+      }
+      expect(screen.queryByText(/Stage 2: Peer Rankings/i)).not.toBeInTheDocument();
+    });
+
+    it('renders a singular "role" label when only one role is present', () => {
+      render(
+        <Stage2
+          kind="role_stub"
+          stage1={[{ label: 'Generator', model: 'openai/gpt-4o', content: 'solo answer' }]}
+          isLoading={false}
+        />,
+      );
+      expect(screen.getByText(/Stage 2: Role Perspectives \(1 role\)/i)).toBeInTheDocument();
+    });
+
+    it('shows a loading state before any stage1 results have arrived', () => {
+      render(<Stage2 kind="role_stub" stage1={[]} isLoading={true} />);
+      expect(screen.getByText(/Roles working…/i)).toBeInTheDocument();
+    });
+
+    it('renders nothing when not loading and stage1 is empty', () => {
+      const { container } = render(<Stage2 kind="role_stub" stage1={[]} isLoading={false} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('truncates long role content with a Show full answer button', () => {
+      const longText =
+        'A long role answer that exceeds the truncation threshold so the dispatcher exposes a Show full answer button — '.repeat(2);
+      render(
+        <Stage2
+          kind="role_stub"
+          stage1={[{ label: 'Generator', model: 'openai/gpt-4o', content: longText }]}
           isLoading={false}
         />,
       );


### PR DESCRIPTION
## Summary
- `src/components/Stage2.jsx`: replace `RoleStubView` (static "roles are complementary — no peer ranking" placeholder) with `RoleView`, a real per-role display for the RoleBased strategy's Stage 2 slot.
- Investigated both unknowns the issue flagged before implementing, against the backend source (`vmm-rada` cloned locally at `~/wrk/projects/vmm-rada/vmm-rada`):
  - **SSE payload shape unchanged.** `internal/council/rolebased.go`'s `runRoleBased` still emits `stage2_complete` with `kind: "role_stub"` and an empty `results` array — `docs/streaming.md:197` was already accurate.
  - **No separate per-role progress events exist.** Role content arrives entirely via the existing `stage1_complete` event. Each `StageOneResult.label` is the role name (Generator/Critic/Verifier/Simplifier) rather than an anonymised "Response A" — no `label_to_model` de-anonymization lookup needed.
- `RoleView` re-displays `stage1` inside the Stage 2 slot, the same pattern `MoaView` already uses for MixtureOfAgents' "Layer 1 — Proposers" panel — intentional duplication, not new.
- `docs/streaming.md`: added a note explaining `role_stub` is the one kind whose Stage 2 content comes from `stage1`, not `metadata` (doc-discipline acceptance criterion).
- `src/components/Stage2.css`: new `.role-*` classes mirroring the existing `.moa-*` structure.
- `src/components/Stage2.test.jsx`: 5 new tests (multi-role render, singular "1 role" label, loading state, empty state, long-content truncation), replacing the old static-placeholder test.

Closes #76

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (48/48, was 44/44)
- [ ] Dev server starts (`npm run dev`)
- [ ] Feature works end-to-end with backend running `DEFAULT_RADA_TYPE=role-based`
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)