### PR TITLE
⚡ task(dx): add XSS assertion rule to context-essentials banned patterns

### DIFF
--- a/.claude/context-essentials.md
+++ b/.claude/context-essentials.md
@@ -59,3 +59,5 @@ contract and require Tech Lead override.
 - No state writes outside `App.jsx`.
 - No TypeScript.
 - No commits skipping pre-commit hooks unless user explicitly requests.
+- No XSS-safety assertions via raw `innerHTML` string matching — use
+  `container.querySelector('script') === null` instead.

--- a/_patterns/anti-patterns.md
+++ b/_patterns/anti-patterns.md
@@ -9,6 +9,8 @@ Approaches that keep failing or are explicitly banned. When about to try one —
 - ❌ State writes outside `App.jsx`
 - ❌ TypeScript (plain JS project by design)
 - ❌ Commits skipping pre-commit hooks unless user explicitly requests
+- ❌ XSS-safety assertions via raw `innerHTML` string matching — use
+  `container.querySelector('script') === null` instead (PR #56 finding)
 
 ## Learned (auto-promoted)
 


### PR DESCRIPTION
## Summary
- `.claude/context-essentials.md` §Banned patterns: add a rule against asserting XSS safety via raw `innerHTML` string matching — use `container.querySelector('script') === null` instead.
- `_patterns/anti-patterns.md`: same rule, same commit (per acceptance criteria — this file is seeded from the same section).

The only durable `/fix-review` finding across 15 reviewed items (2026-W30 dreaming pass) was PR #56: `test-generator` originally asserted XSS safety via brittle `container.innerHTML` string matching, corrected to `querySelector`. This codifies the lesson so it doesn't recur.

Note: `context-essentials.md` is re-injected into every session after compaction and its own header states a ~60-line budget for token cost — this change brings it to 63 lines. Small overage, but flagging per the file's own stated constraint.

Closes #71

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (48/48, unaffected — docs-only change)
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)