### PR TITLE
⚡ chore(dx): run one reviewer for non-src/ diffs in fix-review

### DIFF
--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -43,7 +43,8 @@ triage, not this pipeline.
 
 ```
 Diff-shape gate: does the diff touch src/, package(-lock).json,
-.github/workflows/, or .claude/{skills,agents}/?
+vite.config.js, eslint.config.js, .github/workflows/, or
+.claude/{skills,agents}/?
   yes → REVIEWER_COUNT=3 (full dispatch, below)
   no  → REVIEWER_COUNT=1 (round_1 only — diffs outside all of the above
                            yield 0 findings × 3 reviewers every time observed
@@ -95,15 +96,18 @@ Store it as the **baseline diff** (used in dispatch and arbiter pass).
 ### 1.5. Diff-shape gate
 
 Check whether the diff touches any **security-relevant surface** — not just
-`src/`. Supply-chain files (`package.json`, `package-lock.json`), CI workflow
-files (`.github/workflows/`), and prompt/agent-behavior files
-(`.claude/skills/`, `.claude/agents/`) all warrant full scrutiny even when
-`src/` itself is untouched — a compromised dependency pin, a malicious CI
-step, or an edited agent prompt (including edits to *this skill*) are exactly
-the kind of change three independent reviewers exist to catch:
+`src/`. Supply-chain files (`package.json`, `package-lock.json`), build/lint
+toolchain configs (`vite.config.js`, `eslint.config.js` — a tampered build
+config can inject code into production output; a tampered lint config can
+silently disable security-relevant rules), CI workflow files
+(`.github/workflows/`), and prompt/agent-behavior files (`.claude/skills/`,
+`.claude/agents/`) all warrant full scrutiny even when `src/` itself is
+untouched — a compromised dependency pin, a malicious CI step, or an edited
+agent prompt (including edits to *this skill*) are exactly the kind of
+change three independent reviewers exist to catch:
 
 ```bash
-git diff --name-only main...<branch> | grep -qE '^(src/|package(-lock)?\.json$|\.github/workflows/|\.claude/(skills|agents)/)' \
+git diff --name-only main...<branch> | grep -qE '^(src/|package(-lock)?\.json$|vite\.config\.js$|eslint\.config\.js$|\.github/workflows/|\.claude/(skills|agents)/)' \
   && NEEDS_FULL_REVIEW=true || NEEDS_FULL_REVIEW=false
 ```
 

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -42,10 +42,12 @@ triage, not this pipeline.
 ## Pipeline
 
 ```
-Diff-shape gate: does the diff touch src/?
+Diff-shape gate: does the diff touch src/, package(-lock).json,
+.github/workflows/, or .claude/{skills,agents}/?
   yes → REVIEWER_COUNT=3 (full dispatch, below)
-  no  → REVIEWER_COUNT=1 (round_1 only — non-src/ diffs yield 0 findings
-                           × 3 reviewers every time observed so far)
+  no  → REVIEWER_COUNT=1 (round_1 only — diffs outside all of the above
+                           yield 0 findings × 3 reviewers every time observed
+                           so far, e.g. docs/, context-essentials.md)
        ↓
 Concurrent dispatch (config.yaml reviewers.openrouter.*, REVIEWER_COUNT of them):
   Reviewer model 1 (round_1) ──┐
@@ -92,20 +94,30 @@ Store it as the **baseline diff** (used in dispatch and arbiter pass).
 
 ### 1.5. Diff-shape gate
 
-Check whether the diff touches `src/`:
+Check whether the diff touches any **security-relevant surface** — not just
+`src/`. Supply-chain files (`package.json`, `package-lock.json`), CI workflow
+files (`.github/workflows/`), and prompt/agent-behavior files
+(`.claude/skills/`, `.claude/agents/`) all warrant full scrutiny even when
+`src/` itself is untouched — a compromised dependency pin, a malicious CI
+step, or an edited agent prompt (including edits to *this skill*) are exactly
+the kind of change three independent reviewers exist to catch:
+
 ```bash
-git diff --name-only main...<branch> | grep -q '^src/' && TOUCHES_SRC=true || TOUCHES_SRC=false
+git diff --name-only main...<branch> | grep -qE '^(src/|package(-lock)?\.json$|\.github/workflows/|\.claude/(skills|agents)/)' \
+  && NEEDS_FULL_REVIEW=true || NEEDS_FULL_REVIEW=false
 ```
 
-If `TOUCHES_SRC=false` (no `src/` file in the diff — e.g. `.claude/`, `docs/`,
-config-only PRs), set `REVIEWER_COUNT=1` and dispatch **only `round_1`** in
-Step 3. Three cloud models × zero yield is the confirmed steady state for
-these diffs (PRs #75, #87, #89, #90 — 0 findings × 3 reviewers, every time).
-Mixed diffs (`src/` *and* `.claude/` in the same PR) still get the full
-3-reviewer dispatch — this gate is binary on `src/` presence, not diff size
-or file count.
+If `NEEDS_FULL_REVIEW=false` (none of the above matched — e.g. `docs/`,
+`context-essentials.md`, `_patterns/`, README-only PRs), set
+`REVIEWER_COUNT=1` and dispatch **only `round_1`** in Step 3. Three cloud
+models × zero yield has been the observed steady state for these diffs (PRs
+#75, #87, #89, #90 — 0 findings × 3 reviewers, every time), and the blast
+radius of a doc-only mistake is low enough that a single reviewer plus the
+arbiter's independent scan is adequate.
 
-If `TOUCHES_SRC=true`, set `REVIEWER_COUNT=3` (the existing behavior, unchanged).
+If `NEEDS_FULL_REVIEW=true`, set `REVIEWER_COUNT=3` (the existing behavior,
+unchanged) — this includes mixed diffs (e.g. `src/` *and* `.claude/` in the
+same PR) and PRs that edit this skill's own files.
 
 `REVIEWER_COUNT` drives which models Step 3 calls and what Step 6's PR
 comment reports.
@@ -161,7 +173,7 @@ Build the review prompt combining the baseline diff with instructions:
 Send the prompt to each reviewer model via `ollama-review.sh`. The number of
 models called depends on `REVIEWER_COUNT` from Step 1.5:
 
-**`REVIEWER_COUNT=3`** (diff touches `src/` — default, unchanged behavior):
+**`REVIEWER_COUNT=3`** (diff touches a security-relevant surface — default, unchanged behavior):
 ```bash
 PROMPT="<diff + instructions>"
 
@@ -170,7 +182,7 @@ R2=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_2_m
 R3=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_3_model>)
 ```
 
-**`REVIEWER_COUNT=1`** (no `src/` in diff):
+**`REVIEWER_COUNT=1`** (no security-relevant surface touched):
 ```bash
 PROMPT="<diff + instructions>"
 
@@ -249,8 +261,9 @@ Arbiter: Claude Sonnet 4.6
 </details>
 ```
 
-For a `REVIEWER_COUNT=1` pass (no `src/` in diff), the `Models:` line lists
-only `<round_1_model>`, and vote counts read `N/1` instead of `N/3`.
+For a `REVIEWER_COUNT=1` pass (no security-relevant surface touched), the
+`Models:` line lists only `<round_1_model>`, and vote counts read `N/1`
+instead of `N/3`.
 
 ### 7. Merge decision
 

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -4,7 +4,7 @@ description: Multi-model PR review pipeline. Dispatches the diff concurrently to
 user-invocable: true
 argument-hint: "[pr-number]"
 metadata:
-  version: "2.0.0"
+  version: "2.1.0"
   domain: code-review
   scope: quality-gate
   debt-level: balanced
@@ -42,12 +42,17 @@ triage, not this pipeline.
 ## Pipeline
 
 ```
-Concurrent dispatch (config.yaml reviewers.openrouter.*):
+Diff-shape gate: does the diff touch src/?
+  yes → REVIEWER_COUNT=3 (full dispatch, below)
+  no  → REVIEWER_COUNT=1 (round_1 only — non-src/ diffs yield 0 findings
+                           × 3 reviewers every time observed so far)
+       ↓
+Concurrent dispatch (config.yaml reviewers.openrouter.*, REVIEWER_COUNT of them):
   Reviewer model 1 (round_1) ──┐
-  Reviewer model 2 (round_2) ──┼──→ JSON findings arrays
+  Reviewer model 2 (round_2) ──┼──→ JSON findings arrays   (3-reviewer path only)
   Reviewer model 3 (round_3) ──┘
        ↓
-  Vote tally: group by file:line, attach count N/3 (informational only)
+  Vote tally: group by file:line, attach count N/REVIEWER_COUNT (informational only)
   All findings reach the arbiter — votes do not gate
        ↓
   Arbiter (Claude, main instance)
@@ -84,6 +89,26 @@ gh pr diff $PR
 ```
 
 Store it as the **baseline diff** (used in dispatch and arbiter pass).
+
+### 1.5. Diff-shape gate
+
+Check whether the diff touches `src/`:
+```bash
+git diff --name-only main...<branch> | grep -q '^src/' && TOUCHES_SRC=true || TOUCHES_SRC=false
+```
+
+If `TOUCHES_SRC=false` (no `src/` file in the diff — e.g. `.claude/`, `docs/`,
+config-only PRs), set `REVIEWER_COUNT=1` and dispatch **only `round_1`** in
+Step 3. Three cloud models × zero yield is the confirmed steady state for
+these diffs (PRs #75, #87, #89, #90 — 0 findings × 3 reviewers, every time).
+Mixed diffs (`src/` *and* `.claude/` in the same PR) still get the full
+3-reviewer dispatch — this gate is binary on `src/` presence, not diff size
+or file count.
+
+If `TOUCHES_SRC=true`, set `REVIEWER_COUNT=3` (the existing behavior, unchanged).
+
+`REVIEWER_COUNT` drives which models Step 3 calls and what Step 6's PR
+comment reports.
 
 ### 2. Load reviewer config
 
@@ -133,8 +158,10 @@ Build the review prompt combining the baseline diff with instructions:
 > \"error|warn|sugg\", \"description\": \"...\"}`. Flag only real issues per the Code
 > Review Pyramid. Layer 5 (style) is never flagged."
 
-Send the prompt to each reviewer model via `ollama-review.sh`:
+Send the prompt to each reviewer model via `ollama-review.sh`. The number of
+models called depends on `REVIEWER_COUNT` from Step 1.5:
 
+**`REVIEWER_COUNT=3`** (diff touches `src/` — default, unchanged behavior):
 ```bash
 PROMPT="<diff + instructions>"
 
@@ -143,16 +170,28 @@ R2=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_2_m
 R3=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_3_model>)
 ```
 
+**`REVIEWER_COUNT=1`** (no `src/` in diff):
+```bash
+PROMPT="<diff + instructions>"
+
+R1=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_1_model>)
+```
+Skip R2/R3 entirely — do not call them, and treat their findings as absent
+(not as empty-array votes) when tallying.
+
 Each call returns a JSON array (empty `[]` on parse failure — safe degradation).
 
 ### 4. Tally findings
 
-Merge all three arrays. Group findings by `file:line`. For each unique `file:line`,
-count how many of the 3 models flagged it.
+Merge all called reviewers' arrays (1 or 3, per `REVIEWER_COUNT`). Group findings
+by `file:line`. For each unique `file:line`, count how many of the dispatched
+models flagged it.
 
-Attach `votes: N/3` to each finding as **informational metadata only**. All findings
-(even `votes: 1/3`) are passed to the arbiter — vote counts are a confidence signal,
-not a gate. The arbiter's dismiss rate (~80%) is the actual filter.
+Attach `votes: N/REVIEWER_COUNT` to each finding as **informational metadata
+only** (e.g. `1/3` when `REVIEWER_COUNT=3`, `1/1` when `REVIEWER_COUNT=1`). All
+findings are passed to the arbiter regardless of vote count — votes are a
+confidence signal, not a gate. The arbiter's dismiss rate (~80%) is the actual
+filter.
 
 ### 5. Arbiter pass (Claude, main instance)
 
@@ -191,7 +230,9 @@ gh issue create --title "..." --body "..."
 
 ### 6. Post PR comment
 
-Post a single collapsible summary:
+Post a single collapsible summary. The `Models:` line lists only the models
+actually dispatched (per `REVIEWER_COUNT` from Step 1.5) — never claim three
+reviewers ran when only `round_1` was called:
 
 ```
 <details>
@@ -207,6 +248,9 @@ Arbiter: Claude Sonnet 4.6
 
 </details>
 ```
+
+For a `REVIEWER_COUNT=1` pass (no `src/` in diff), the `Models:` line lists
+only `<round_1_model>`, and vote counts read `N/1` instead of `N/3`.
 
 ### 7. Merge decision
 


### PR DESCRIPTION
## Summary
- `.claude/skills/fix-review/SKILL.md`: adds a diff-shape gate after Step 1. If a diff touches none of `src/`, `package(-lock).json`, `.github/workflows/`, or `.claude/{skills,agents}/`, dispatch only `round_1` instead of all 3 reviewer models.
- Motivation: three cloud models × zero yield has been the confirmed steady state for non-`src/`-only diffs this session — PRs #75, #87, #89, #90 each got 0 findings from all 3 reviewers.
- Updates the vote tally (`N/REVIEWER_COUNT`), the PR-comment template (`Models:` line lists only what actually ran), and the top-level pipeline diagram to match.

**Security review caught a self-referential gap** in the first draft: gating on `^src/` alone would have downgraded package.json/lockfile changes (supply chain), CI workflow edits, and `.claude/skills/`\|`.claude/agents/` edits (agent-behavior prompts — including this very skill's own file) to a single reviewer. Confirmed concretely: this PR's own diff would have gotten 1-reviewer treatment under the original rule. Widened the gate to require any of those four categories before downgrading — verified the regex against 6 representative paths (see second commit).

Closes #82

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (48/48, unaffected — docs-only change)
- [x] Regex verified against 6 representative file paths (src/, docs/, package.json, package-lock.json, .claude/skills/, unrelated `packages.json` false-positive check)
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)