### PR TITLE
⚖️ test: cover untested components and Markdown XSS gap

### DIFF
--- a/.claude/agent-memory/test-generator/MEMORY.md
+++ b/.claude/agent-memory/test-generator/MEMORY.md
@@ -1,0 +1,3 @@
+# test-generator memory index
+
+- `vmm-rada-web-ui-quirks.md` — Vitest/RTL quirks specific to this repo (globals, ambiguous-text-query pitfall, Stage component render patterns).

--- a/.claude/agent-memory/test-generator/vmm-rada-web-ui-quirks.md
+++ b/.claude/agent-memory/test-generator/vmm-rada-web-ui-quirks.md
@@ -1,0 +1,37 @@
+---
+name: vmm-rada-web-ui-quirks
+description: Non-obvious Vitest/RTL quirks specific to this repo's component shapes, useful when generating or extending tests for App.jsx/Stage*.jsx/ChatInterface.jsx.
+type: project
+---
+
+- **`vi` is global** in this project (`vitest.config` sets `test.globals: true`
+  via `vite.config.js`) — no `import { vi } from 'vitest'` needed, matching
+  the pattern already used in `App.test.jsx`/`Stage2.test.jsx`.
+  **Why:** avoids import-vs-global inconsistency across new test files.
+  **How to apply:** just call `vi.fn()`/`vi.mock()`/`vi.hoisted()` directly.
+
+- **Avoid case-insensitive regex text queries when a label and its rendered
+  content share a substring** — e.g. Stage3's header span literally reads
+  "Final Answer" and its content `<p>` can independently contain the word
+  "Final" (e.g. "Final answer text" from LLM content), producing a
+  `getByText(/Final Answer/i)` multiple-match error.
+  **Why:** RTL's `getByText` throws on ambiguous matches; regex loosens exact
+  matching more than expected when test fixtures reuse header vocabulary in
+  body content.
+  **Evidence:** hit this exact collision in `ChatInterface.test.jsx` when
+  asserting Stage3's "Final Answer" header alongside fixture content
+  "Final answer text" — fixed by switching to the exact string
+  `screen.getByText('Final Answer')`.
+  **How to apply:** prefer exact string matches for short header/label text
+  when the render tree also includes prop-driven fixture content; save regex
+  matching for cases where no legitimate ambiguity risk exists.
+
+- **`Stage0`/`Stage1`/`Stage3` are plain prop-driven components with no
+  internal accordion state persisted across prop changes** — `Stage1`'s
+  accordion starts collapsed and `activeTab` resets are not needed between
+  tests since each `render()` call is a fresh mount.
+  **Why:** simplifies test setup — no need to manage/reset internal state
+  between assertions within a single test, just drive via `userEvent` clicks
+  in sequence.
+  **How to apply:** test the collapsed state first, then click to expand,
+  then click tabs, all within one `it()` block using a single `render()`.

--- a/src/components/ChatInterface.test.jsx
+++ b/src/components/ChatInterface.test.jsx
@@ -1,0 +1,208 @@
+// Tests for ChatInterface.jsx — the main chat panel. Treated as an
+// integration-of-props component: Stage0-3 and EmptyState are real
+// (already tested elsewhere), so we assert on their surface-level rendered
+// output rather than mocking them. No api.js involvement — this component is
+// purely prop-driven.
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChatInterface from './ChatInterface';
+
+function baseProps(overrides = {}) {
+  return {
+    conversation: null,
+    onSendMessage: vi.fn(),
+    onAnswerSubmit: vi.fn(),
+    isLoading: false,
+    isConversationClosed: false,
+    sidebarOpen: true,
+    onToggleSidebar: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeConversation(overrides = {}) {
+  return {
+    id: 'conv-1',
+    title: 'A Conversation',
+    messages: [],
+    ...overrides,
+  };
+}
+
+describe('ChatInterface', () => {
+  it('shows the "select or create" placeholder when conversation is null', () => {
+    render(<ChatInterface {...baseProps({ conversation: null })} />);
+    expect(
+      screen.getByText(/Select or create a conversation to get started/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders EmptyState when the conversation has no messages yet', () => {
+    render(<ChatInterface {...baseProps({ conversation: makeConversation() })} />);
+    expect(screen.getByText('Explain the trolley problem')).toBeInTheDocument();
+  });
+
+  it('renders a user message via Markdown and an assistant message dispatching to Stage3', () => {
+    const conversation = makeConversation({
+      messages: [
+        { role: 'user', content: 'Hi there' },
+        {
+          role: 'assistant',
+          stage1: null,
+          stage2: null,
+          stage3: { content: 'Final answer text', model: 'openai/gpt-4o' },
+          metadata: null,
+          loading: {},
+          error: null,
+          pendingClarification: null,
+        },
+      ],
+    });
+    render(<ChatInterface {...baseProps({ conversation })} />);
+
+    expect(screen.getByText('You')).toBeInTheDocument();
+    expect(screen.getByText('Hi there')).toBeInTheDocument();
+    expect(screen.getByText('VMM Rada')).toBeInTheDocument();
+    // Stage3 surface: header + content rendered through Markdown.
+    expect(screen.getByText('Final Answer')).toBeInTheDocument();
+    expect(screen.getByText('Final answer text')).toBeInTheDocument();
+  });
+
+  it('renders the Stage3 error banner when an assistant message carries an error', () => {
+    const conversation = makeConversation({
+      messages: [
+        { role: 'user', content: 'Hi there' },
+        {
+          role: 'assistant',
+          stage1: null,
+          stage2: null,
+          stage3: null,
+          metadata: null,
+          loading: {},
+          error: 'council quorum not met',
+          pendingClarification: null,
+        },
+      ],
+    });
+    render(<ChatInterface {...baseProps({ conversation })} />);
+    expect(screen.getByText('council quorum not met')).toBeInTheDocument();
+  });
+
+  it('shows the conversation title, stripped of markdown, in the header', () => {
+    const conversation = makeConversation({ title: '**Bold** Title', messages: [] });
+    render(<ChatInterface {...baseProps({ conversation })} />);
+    expect(screen.getByText('Bold Title')).toBeInTheDocument();
+  });
+
+  it('calls onSendMessage with the trimmed text when the form is submitted', async () => {
+    const onSendMessage = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ChatInterface
+        {...baseProps({ conversation: makeConversation(), onSendMessage })}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(/Ask a question/i);
+    await user.type(input, '  What is TCP?  ');
+    await user.click(screen.getByRole('button', { name: /Send/i }));
+
+    expect(onSendMessage).toHaveBeenCalledTimes(1);
+    expect(onSendMessage).toHaveBeenCalledWith('What is TCP?');
+  });
+
+  it('prefixes the message with Context when the context textarea has text', async () => {
+    const onSendMessage = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ChatInterface
+        {...baseProps({ conversation: makeConversation(), onSendMessage })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Context/i }));
+    const contextTextarea = screen.getByPlaceholderText(/Background information/i);
+    await user.type(contextTextarea, 'Some background');
+
+    const input = screen.getByPlaceholderText(/Ask a question/i);
+    await user.type(input, 'What is TCP?');
+    await user.click(screen.getByRole('button', { name: /Send/i }));
+
+    expect(onSendMessage).toHaveBeenCalledWith(
+      'Context:\nSome background\n\nQuestion:\nWhat is TCP?',
+    );
+  });
+
+  it('does not call onSendMessage when the input is only whitespace', async () => {
+    const onSendMessage = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ChatInterface
+        {...baseProps({ conversation: makeConversation(), onSendMessage })}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(/Ask a question/i);
+    await user.type(input, '   ');
+    // Send button should be disabled for whitespace-only input.
+    expect(screen.getByRole('button', { name: /Send/i })).toBeDisabled();
+  });
+
+  it('disables the input and shows "conversation has ended" when isConversationClosed', () => {
+    render(
+      <ChatInterface
+        {...baseProps({ conversation: makeConversation(), isConversationClosed: true })}
+      />,
+    );
+    const input = screen.getByPlaceholderText(/This conversation has ended/i);
+    expect(input).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Send/i })).toBeDisabled();
+  });
+
+  it('disables the input while isLoading is true', () => {
+    render(
+      <ChatInterface
+        {...baseProps({ conversation: makeConversation(), isLoading: true })}
+      />,
+    );
+    const input = screen.getByPlaceholderText(/Ask a question/i);
+    expect(input).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Send/i })).toBeDisabled();
+  });
+
+  it('swaps the placeholder to prompt for clarification answers when the last message is pending', () => {
+    const conversation = makeConversation({
+      messages: [
+        {
+          role: 'assistant',
+          stage1: null,
+          stage2: null,
+          stage3: null,
+          metadata: null,
+          loading: {},
+          error: null,
+          pendingClarification: { round: 1, questions: [{ id: 'q1', text: 'Which framework?' }] },
+        },
+      ],
+    });
+    render(<ChatInterface {...baseProps({ conversation })} />);
+    expect(
+      screen.getByPlaceholderText(/Answer the questions above to continue/i),
+    ).toBeInTheDocument();
+    // Stage0 itself renders the question text and its own submit/skip controls.
+    expect(screen.getByText('Which framework?')).toBeInTheDocument();
+  });
+
+  it('shows the sidebar-open button only when the sidebar is closed', () => {
+    const { rerender } = render(
+      <ChatInterface {...baseProps({ conversation: makeConversation(), sidebarOpen: true })} />,
+    );
+    expect(screen.queryByRole('button', { name: /Open sidebar/i })).not.toBeInTheDocument();
+
+    rerender(
+      <ChatInterface {...baseProps({ conversation: makeConversation(), sidebarOpen: false })} />,
+    );
+    expect(screen.getByRole('button', { name: /Open sidebar/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/EmptyState.test.jsx
+++ b/src/components/EmptyState.test.jsx
@@ -1,0 +1,47 @@
+// Tests for EmptyState.jsx — pure presentational component with 4 suggested
+// prompt chips.
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EmptyState from './EmptyState';
+
+const PROMPTS = [
+  'Explain the trolley problem',
+  'How does TCP differ from UDP?',
+  'What is quantum entanglement?',
+  'Compare merge sort and quicksort',
+];
+
+describe('EmptyState', () => {
+  it('renders all 4 suggested-prompt buttons', () => {
+    render(<EmptyState onSendMessage={vi.fn()} isLoading={false} />);
+    for (const prompt of PROMPTS) {
+      expect(screen.getByRole('button', { name: prompt })).toBeInTheDocument();
+    }
+  });
+
+  it('calls onSendMessage with the prompt text when a chip is clicked', async () => {
+    const onSendMessage = vi.fn();
+    const user = userEvent.setup();
+    render(<EmptyState onSendMessage={onSendMessage} isLoading={false} />);
+
+    await user.click(screen.getByRole('button', { name: PROMPTS[1] }));
+
+    expect(onSendMessage).toHaveBeenCalledTimes(1);
+    expect(onSendMessage).toHaveBeenCalledWith(PROMPTS[1]);
+  });
+
+  it('disables all prompt chips while isLoading is true', () => {
+    render(<EmptyState onSendMessage={vi.fn()} isLoading={true} />);
+    for (const prompt of PROMPTS) {
+      expect(screen.getByRole('button', { name: prompt })).toBeDisabled();
+    }
+  });
+
+  it('enables all prompt chips when isLoading is false', () => {
+    render(<EmptyState onSendMessage={vi.fn()} isLoading={false} />);
+    for (const prompt of PROMPTS) {
+      expect(screen.getByRole('button', { name: prompt })).not.toBeDisabled();
+    }
+  });
+});

--- a/src/components/Markdown.test.jsx
+++ b/src/components/Markdown.test.jsx
@@ -55,17 +55,20 @@ describe('Markdown', () => {
       expect(container.querySelector('img[onerror]')).toBeNull();
     });
 
-    it('never renders a script tag from an inline HTML anchor with javascript: href', () => {
+    it('strips the javascript: scheme from a link href rather than dropping the link', () => {
       const malicious = '[click me](javascript:window.xssed=true)';
       const { container } = render(<Markdown>{malicious}</Markdown>);
 
       expect(container.querySelector('script')).toBeNull();
-      // If a link is rendered at all, it must not carry a javascript: URI —
-      // react-markdown's default URI transform strips these.
+      // react-markdown's default URI transform renders the anchor but strips
+      // the dangerous scheme (href becomes ""), never drops the link outright.
+      // Assert the link's presence unconditionally — a soft `if (link)` guard
+      // would silently pass if a future regression made the link disappear
+      // entirely instead of sanitizing it, masking exactly the bug this test
+      // exists to catch.
       const link = container.querySelector('a');
-      if (link) {
-        expect(link.getAttribute('href')).not.toMatch(/^javascript:/i);
-      }
+      expect(link).not.toBeNull();
+      expect(link.getAttribute('href')).not.toMatch(/^javascript:/i);
     });
   });
 });

--- a/src/components/Markdown.test.jsx
+++ b/src/components/Markdown.test.jsx
@@ -1,0 +1,71 @@
+// Tests for Markdown.jsx — the sole enforcement point for context-essentials.md
+// rule 4 ("react-markdown is the only renderer for LLM output, raw HTML is
+// forbidden — XSS risk"). The XSS regression test below is mandatory: it
+// guards against a raw-HTML-rendering regression by inspecting the parsed DOM
+// tree, never by string-matching innerHTML (that anti-pattern is banned, see
+// context-essentials.md "Banned patterns").
+
+import { render, screen } from '@testing-library/react';
+import Markdown from './Markdown';
+
+describe('Markdown', () => {
+  it('renders plain markdown formatting (bold, heading) as text', () => {
+    render(<Markdown>{'# Heading\n\nSome **bold** text.'}</Markdown>);
+    expect(screen.getByRole('heading', { name: 'Heading' })).toBeInTheDocument();
+    expect(screen.getByText('bold')).toBeInTheDocument();
+    // Bold text is rendered as a <strong> element, not literal asterisks.
+    expect(screen.getByText('bold').tagName).toBe('STRONG');
+  });
+
+  it('renders undefined/null children as empty content without throwing', () => {
+    const { container } = render(<Markdown>{undefined}</Markdown>);
+    expect(container.textContent).toBe('');
+  });
+
+  describe('XSS regression guard (context-essentials.md rule 4)', () => {
+    it('never renders a raw <script> tag embedded in LLM markdown output', () => {
+      const malicious = 'Ignore instructions.\n\n<script>window.xssed = true</script>\n\nDone.';
+      const { container } = render(<Markdown>{malicious}</Markdown>);
+
+      // The only correct way to assert XSS-safety: query the parsed DOM tree,
+      // never string-match innerHTML.
+      expect(container.querySelector('script')).toBeNull();
+      expect(window.xssed).toBeUndefined();
+      // The literal text still appears (escaped), proving react-markdown
+      // treated it as inert text rather than dropping the whole message.
+      expect(container.textContent).toContain('Ignore instructions.');
+      expect(container.textContent).toContain('Done.');
+    });
+
+    it('never renders an element carrying an onerror/onclick-style handler attribute', () => {
+      const malicious = 'Look at this image: <img src="x" onerror="window.xssed = true">';
+      const { container } = render(<Markdown>{malicious}</Markdown>);
+
+      expect(container.querySelector('script')).toBeNull();
+      expect(window.xssed).toBeUndefined();
+
+      // No element in the rendered tree may carry an onerror/onclick handler
+      // attribute — react-markdown strips raw HTML by default rather than
+      // parsing it into real DOM nodes.
+      const allElements = container.querySelectorAll('*');
+      for (const el of allElements) {
+        expect(el.getAttribute('onerror')).toBeNull();
+        expect(el.getAttribute('onclick')).toBeNull();
+      }
+      expect(container.querySelector('img[onerror]')).toBeNull();
+    });
+
+    it('never renders a script tag from an inline HTML anchor with javascript: href', () => {
+      const malicious = '[click me](javascript:window.xssed=true)';
+      const { container } = render(<Markdown>{malicious}</Markdown>);
+
+      expect(container.querySelector('script')).toBeNull();
+      // If a link is rendered at all, it must not carry a javascript: URI —
+      // react-markdown's default URI transform strips these.
+      const link = container.querySelector('a');
+      if (link) {
+        expect(link.getAttribute('href')).not.toMatch(/^javascript:/i);
+      }
+    });
+  });
+});

--- a/src/components/Sidebar.test.jsx
+++ b/src/components/Sidebar.test.jsx
@@ -1,0 +1,104 @@
+// Tests for Sidebar.jsx — the conversation list. Uses the real stripMarkdown
+// from ../utils (pure function, no need to mock).
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Sidebar from './Sidebar';
+
+function baseProps(overrides = {}) {
+  return {
+    conversations: [],
+    currentConversationId: null,
+    onSelectConversation: vi.fn(),
+    onNewConversation: vi.fn(),
+    onDeleteConversation: vi.fn(),
+    onRenameConversation: vi.fn(),
+    isOpen: true,
+    onToggle: vi.fn(),
+    theme: 'dark',
+    onToggleTheme: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('Sidebar', () => {
+  it('shows the empty-state message when there are no conversations', () => {
+    render(<Sidebar {...baseProps()} />);
+    expect(screen.getByText('No conversations yet')).toBeInTheDocument();
+  });
+
+  it('renders one item per conversation, with markdown stripped from the title', () => {
+    const conversations = [
+      { id: 'c1', title: '**Bold** Title', created_at: '2026-05-02T12:00:00Z' },
+      { id: 'c2', title: 'Plain Title', created_at: '2026-05-03T12:00:00Z' },
+    ];
+    render(<Sidebar {...baseProps({ conversations })} />);
+    expect(screen.getByText('Bold Title')).toBeInTheDocument();
+    expect(screen.getByText('Plain Title')).toBeInTheDocument();
+    expect(screen.queryByText('**Bold** Title')).not.toBeInTheDocument();
+  });
+
+  it('falls back to "New Conversation" when title is empty', () => {
+    const conversations = [{ id: 'c1', title: '', created_at: '2026-05-02T12:00:00Z' }];
+    render(<Sidebar {...baseProps({ conversations })} />);
+    expect(screen.getByText('New Conversation')).toBeInTheDocument();
+  });
+
+  it('calls onSelectConversation when a conversation item is clicked', async () => {
+    const onSelectConversation = vi.fn();
+    const conversations = [{ id: 'c1', title: 'One', created_at: '2026-05-02T12:00:00Z' }];
+    const user = userEvent.setup();
+    render(<Sidebar {...baseProps({ conversations, onSelectConversation })} />);
+
+    await user.click(screen.getByText('One'));
+
+    expect(onSelectConversation).toHaveBeenCalledWith('c1');
+  });
+
+  it('calls onNewConversation when "+ New Conversation" is clicked', async () => {
+    const onNewConversation = vi.fn();
+    const user = userEvent.setup();
+    render(<Sidebar {...baseProps({ onNewConversation })} />);
+
+    await user.click(screen.getByRole('button', { name: /New Conversation/i }));
+
+    expect(onNewConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onToggleTheme when the theme toggle button is clicked', async () => {
+    const onToggleTheme = vi.fn();
+    const user = userEvent.setup();
+    render(<Sidebar {...baseProps({ onToggleTheme })} />);
+
+    await user.click(screen.getByRole('button', { name: /Switch to light theme/i }));
+
+    expect(onToggleTheme).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the actions dropdown to reveal Rename/Delete, and Delete calls onDeleteConversation', async () => {
+    const onDeleteConversation = vi.fn();
+    const conversations = [{ id: 'c1', title: 'One', created_at: '2026-05-02T12:00:00Z' }];
+    const user = userEvent.setup();
+    render(<Sidebar {...baseProps({ conversations, onDeleteConversation })} />);
+
+    expect(screen.queryByRole('button', { name: 'Rename' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Conversation actions'));
+
+    expect(screen.getByRole('button', { name: 'Rename' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(onDeleteConversation).toHaveBeenCalledWith('c1');
+  });
+
+  it('marks the current conversation as active and applies the collapsed class when isOpen is false', () => {
+    const conversations = [{ id: 'c1', title: 'One', created_at: '2026-05-02T12:00:00Z' }];
+    const { container } = render(
+      <Sidebar {...baseProps({ conversations, currentConversationId: 'c1', isOpen: false })} />,
+    );
+    expect(container.querySelector('.sidebar.collapsed')).not.toBeNull();
+    expect(container.querySelector('.conversation-item.active')).not.toBeNull();
+  });
+});

--- a/src/components/Stage0.test.jsx
+++ b/src/components/Stage0.test.jsx
@@ -1,0 +1,109 @@
+// Tests for Stage0.jsx — the clarification-round UI. Renders null when there
+// is nothing to show, a loading spinner while questions are being generated,
+// and per-question textareas with Submit/Skip actions once questions arrive.
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Stage0 from './Stage0';
+
+describe('Stage0', () => {
+  it('renders nothing when there is no pending clarification and not loading', () => {
+    const { container } = render(
+      <Stage0 pendingClarification={null} isLoading={false} onSubmit={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows a loading indicator while identifying clarification questions', () => {
+    render(<Stage0 pendingClarification={null} isLoading={true} onSubmit={vi.fn()} />);
+    expect(screen.getByText(/Identifying clarification questions/i)).toBeInTheDocument();
+  });
+
+  it('renders one question per entry with the round number and answer textareas', () => {
+    const pendingClarification = {
+      round: 2,
+      questions: [
+        { id: 'q1', text: 'Which framework?' },
+        { id: 'q2', text: 'What is the deadline?' },
+      ],
+    };
+    render(
+      <Stage0
+        pendingClarification={pendingClarification}
+        isLoading={false}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/round 2/i)).toBeInTheDocument();
+    expect(screen.getByText('Which framework?')).toBeInTheDocument();
+    expect(screen.getByText('What is the deadline?')).toBeInTheDocument();
+    expect(screen.getAllByPlaceholderText(/Your answer/i)).toHaveLength(2);
+    expect(screen.getByRole('button', { name: /Submit answers/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Skip/i })).toBeInTheDocument();
+  });
+
+  it('calls onSubmit with typed answers when Submit answers is clicked', async () => {
+    const onSubmit = vi.fn();
+    const pendingClarification = {
+      round: 1,
+      questions: [
+        { id: 'q1', text: 'Which framework?' },
+        { id: 'q2', text: 'What is the deadline?' },
+      ],
+    };
+    const user = userEvent.setup();
+    render(
+      <Stage0
+        pendingClarification={pendingClarification}
+        isLoading={false}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const textareas = screen.getAllByPlaceholderText(/Your answer/i);
+    await user.type(textareas[0], 'React');
+    await user.type(textareas[1], 'Next week');
+    await user.click(screen.getByRole('button', { name: /Submit answers/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith([
+      { id: 'q1', text: 'React' },
+      { id: 'q2', text: 'Next week' },
+    ]);
+  });
+
+  it('calls onSubmit with empty-text answers when Skip is clicked, even if text was drafted', async () => {
+    const onSubmit = vi.fn();
+    const pendingClarification = {
+      round: 1,
+      questions: [{ id: 'q1', text: 'Which framework?' }],
+    };
+    const user = userEvent.setup();
+    render(
+      <Stage0
+        pendingClarification={pendingClarification}
+        isLoading={false}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Your answer/i);
+    await user.type(textarea, 'React');
+    await user.click(screen.getByRole('button', { name: /Skip/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith([{ id: 'q1', text: '' }]);
+  });
+
+  it('renders both the loading indicator and pending questions when both are provided', () => {
+    render(
+      <Stage0
+        pendingClarification={{ round: 1, questions: [{ id: 'q1', text: 'Which framework?' }] }}
+        isLoading={true}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Identifying clarification questions/i)).toBeInTheDocument();
+    expect(screen.getByText('Which framework?')).toBeInTheDocument();
+  });
+});

--- a/src/components/Stage1.test.jsx
+++ b/src/components/Stage1.test.jsx
@@ -1,0 +1,102 @@
+// Tests for Stage1.jsx — the individual-responses accordion. Follows the same
+// dispatcher/accordion test pattern used in Stage2.test.jsx: render, expand
+// the accordion, switch tabs, verify per-response content.
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Stage1 from './Stage1';
+
+describe('Stage1', () => {
+  it('renders nothing when not loading and there are no responses', () => {
+    const { container } = render(<Stage1 responses={[]} isLoading={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when responses is undefined and not loading', () => {
+    const { container } = render(<Stage1 responses={undefined} isLoading={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows a loading state while collecting responses', () => {
+    render(<Stage1 responses={[]} isLoading={true} />);
+    expect(screen.getByText(/Collecting individual responses/i)).toBeInTheDocument();
+  });
+
+  it('shows the collapsed accordion header with a model count once responses arrive', () => {
+    const responses = [
+      { model: 'openai/gpt-4o', content: 'answer one' },
+      { model: 'anthropic/claude-sonnet-4-5', content: 'answer two' },
+    ];
+    render(<Stage1 responses={responses} isLoading={false} />);
+    expect(screen.getByText(/Stage 1: Individual Responses \(2 models\)/i)).toBeInTheDocument();
+    // Collapsed by default: tab content not shown yet.
+    expect(screen.queryByText('answer one')).not.toBeInTheDocument();
+  });
+
+  it('uses singular "model" wording for exactly one response', () => {
+    render(
+      <Stage1
+        responses={[{ model: 'openai/gpt-4o', content: 'solo answer' }]}
+        isLoading={false}
+      />,
+    );
+    expect(screen.getByText(/Stage 1: Individual Responses \(1 model\)/i)).toBeInTheDocument();
+  });
+
+  it('expands on click to show tabs and the first response by default', async () => {
+    const responses = [
+      { model: 'openai/gpt-4o', content: 'answer one' },
+      { model: 'anthropic/claude-sonnet-4-5', content: 'answer two' },
+    ];
+    const user = userEvent.setup();
+    render(<Stage1 responses={responses} isLoading={false} />);
+
+    const accordionButton = screen.getByRole('button', {
+      name: /Stage 1: Individual Responses/i,
+    });
+    expect(accordionButton).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(accordionButton);
+
+    expect(accordionButton).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('answer one')).toBeInTheDocument();
+    expect(screen.getByText('openai/gpt-4o')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'gpt-4o' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'claude-sonnet-4-5' })).toBeInTheDocument();
+  });
+
+  it('switches tabs to show the selected model response, and can collapse again', async () => {
+    const responses = [
+      { model: 'openai/gpt-4o', content: 'answer one' },
+      { model: 'anthropic/claude-sonnet-4-5', content: 'answer two' },
+    ];
+    const user = userEvent.setup();
+    render(<Stage1 responses={responses} isLoading={false} />);
+
+    await user.click(screen.getByRole('button', { name: /Stage 1: Individual Responses/i }));
+    await user.click(screen.getByRole('button', { name: 'claude-sonnet-4-5' }));
+
+    expect(screen.getByText('answer two')).toBeInTheDocument();
+    expect(screen.queryByText('answer one')).not.toBeInTheDocument();
+    expect(screen.getByText('anthropic/claude-sonnet-4-5')).toBeInTheDocument();
+
+    // Collapse again — tab content should disappear.
+    await user.click(screen.getByRole('button', { name: /Stage 1: Individual Responses/i }));
+    expect(screen.queryByText('answer two')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the full model string for a tab label when there is no slash', async () => {
+    const user = userEvent.setup();
+    render(
+      <Stage1
+        responses={[{ model: 'localmodel', content: 'local answer' }]}
+        isLoading={false}
+      />,
+    );
+    await user.click(
+      screen.getByRole('button', { name: /Stage 1: Individual Responses/i }),
+    );
+    expect(screen.getByRole('button', { name: 'localmodel' })).toBeInTheDocument();
+    expect(screen.getByText('local answer')).toBeInTheDocument();
+  });
+});

--- a/src/components/Stage3.test.jsx
+++ b/src/components/Stage3.test.jsx
@@ -1,0 +1,51 @@
+// Tests for Stage3.jsx — the final-answer / error display. Renders null when
+// there is nothing to show; otherwise shows the model name (short form) and
+// content via Markdown, or an error banner when `error` is set.
+
+import { render, screen } from '@testing-library/react';
+import Stage3 from './Stage3';
+
+describe('Stage3', () => {
+  it('renders nothing when both finalResponse and error are falsy', () => {
+    const { container } = render(<Stage3 finalResponse={null} error={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the final answer content and the short model name', () => {
+    render(
+      <Stage3
+        finalResponse={{ content: 'The **final** answer.', model: 'openai/gpt-4o-mini' }}
+        error={null}
+      />,
+    );
+    expect(screen.getByText(/Final Answer/i)).toBeInTheDocument();
+    expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument();
+    expect(screen.getByText('final')).toBeInTheDocument();
+  });
+
+  it('falls back to the full model string when there is no slash-separated short form', () => {
+    render(
+      <Stage3
+        finalResponse={{ content: 'answer text', model: 'localmodel' }}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('localmodel')).toBeInTheDocument();
+  });
+
+  it('renders the error banner instead of content when error is set', () => {
+    render(
+      <Stage3
+        finalResponse={null}
+        error="council quorum not met"
+      />,
+    );
+    expect(screen.getByText('council quorum not met')).toBeInTheDocument();
+    expect(screen.getByText(/Final Answer/i)).toBeInTheDocument();
+  });
+
+  it('does not render a model badge when finalResponse is absent, even with an error', () => {
+    const { container } = render(<Stage3 finalResponse={null} error="boom" />);
+    expect(container.querySelector('.stage3-model')).toBeNull();
+  });
+});

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,0 +1,50 @@
+// Tests for utils.js — pure functions, no React involved.
+
+import { stripMarkdown } from './utils';
+
+describe('stripMarkdown', () => {
+  it('strips **bold** markers', () => {
+    expect(stripMarkdown('This is **bold** text.')).toBe('This is bold text.');
+  });
+
+  it('strips *italic* markers', () => {
+    expect(stripMarkdown('This is *italic* text.')).toBe('This is italic text.');
+  });
+
+  it('strips __bold__ markers', () => {
+    expect(stripMarkdown('This is __bold__ text.')).toBe('This is bold text.');
+  });
+
+  it('strips _italic_ markers', () => {
+    expect(stripMarkdown('This is _italic_ text.')).toBe('This is italic text.');
+  });
+
+  it('strips `code` markers', () => {
+    expect(stripMarkdown('Run `npm test` now.')).toBe('Run npm test now.');
+  });
+
+  it('strips leading # heading markers', () => {
+    expect(stripMarkdown('# Heading One')).toBe('Heading One');
+    expect(stripMarkdown('### Heading Three')).toBe('Heading Three');
+  });
+
+  it('strips heading markers on multiple lines', () => {
+    expect(stripMarkdown('# Title\n## Subtitle\nBody text')).toBe(
+      'Title\nSubtitle\nBody text',
+    );
+  });
+
+  it('strips a combination of markdown patterns in a single string', () => {
+    expect(stripMarkdown('# Title\n**bold** and _italic_ and `code`')).toBe(
+      'Title\nbold and italic and code',
+    );
+  });
+
+  it('returns plain text unchanged when there is no markdown', () => {
+    expect(stripMarkdown('Just plain text.')).toBe('Just plain text.');
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(stripMarkdown('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 8 colocated Vitest test files via the `test-generator` agent (first invocation in this repo — built for exactly this per the 2026-W30 dreaming report §5).
- `Markdown.test.jsx`: mandatory XSS regression tests — `<script>` tag, `<img onerror>`, `javascript:` href — all asserted via `container.querySelector`, never `innerHTML` string matching (the exact anti-pattern banned in #71).
- `Stage0/Stage1/Stage3.test.jsx`: clarification round, individual responses, final answer/error display.
- `Sidebar.test.jsx`: conversation list, rename/delete dropdown, theme toggle.
- `ChatInterface.test.jsx`: integration-level coverage — renders real Stage0-3 + EmptyState children, tests the input form's Context-prefix logic and disabled states.
- `EmptyState.test.jsx`, `utils.test.js`.
- 106 tests / 11 files (was 48 / 3).

**Security review caught a real gap**: the `javascript:` href test wrapped its assertion in `if (link) { ... }` — a soft guard that would silently pass if a future regression made the link disappear entirely instead of sanitizing it. Verified empirically (via a throwaway test dumping `container.innerHTML`) that react-markdown always renders the anchor and sanitizes the href to `""`, never drops the link — so hardened the assertion to require the link's presence unconditionally. Fixed in second commit.

Records a durable `test-generator` memory note (`.claude/agent-memory/test-generator/`) about an ambiguous `getByText` regex collision hit during self-testing (Stage3's "Final Answer" header vs. fixture content containing "Final") and this repo's Vitest globals convention.

Closes #78

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (106/106, up from 48/48)
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)