### PR TITLE
⚖️ docs: diff backend docs/api.md against frontend docs/api-contract.md

### DIFF
--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -21,6 +21,12 @@ contain JSON payloads.
   replay — that claim was never true against current backend behavior. See
   gh#94 for the frontend bug this false assumption produced (`deriveStage2Kind`
   ignores the now-confirmed-present `metadata.council_type` on replay).
+  **Security note:** this means `label_to_model` (which model produced which
+  response) is retrievable indefinitely via `GET /api/conversations/{id}`,
+  not just during the live session — this project has no auth layer, so
+  anyone with network access to the backend can read it for any past
+  conversation. Flagging for awareness; whether that's an acceptable trade-off
+  is a backend/product decision, out of scope for this frontend-docs fix.
 - **Strategy is server-side configuration, not a client concern.** The same
   two endpoints (`/message`, `/message/stream`) serve all seven deliberation
   strategies. The frontend sends `council_type` (currently hardcoded to

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -11,11 +11,16 @@ contain JSON payloads.
   message and one assistant message. Sending a second message to an existing
   conversation is not supported by the UI — the frontend creates a new
   conversation for each question.
-- **`metadata` is ephemeral.** `label_to_model`, `aggregate_rankings`, and the
-  strategy-specific fields (`vote_tally`, `rank_refine`, `debate`,
-  `moa_aggregator`, `delphi`) are only returned during the streaming/blocking
-  response and are not persisted. `GET /api/conversations/{id}` does not
-  include them.
+- **`metadata` IS persisted and returned on replay.** Verified against backend
+  source (`internal/storage/storage.go` `SaveAssistantMessage` — marshals the
+  full `council.AssistantMessage` struct, `Metadata` field has no `omitempty`
+  or `-` tag) — `GET /api/conversations/{id}` returns the same `metadata`
+  object that was present at streaming/blocking-response time, byte-for-byte
+  (`Conversation.Messages` is stored as raw JSON). This corrects a prior
+  version of this doc that claimed metadata was ephemeral and stripped on
+  replay — that claim was never true against current backend behavior. See
+  gh#94 for the frontend bug this false assumption produced (`deriveStage2Kind`
+  ignores the now-confirmed-present `metadata.council_type` on replay).
 - **Strategy is server-side configuration, not a client concern.** The same
   two endpoints (`/message`, `/message/stream`) serve all seven deliberation
   strategies. The frontend sends `council_type` (currently hardcoded to
@@ -108,7 +113,7 @@ Response:
 DELETE /api/conversations/{id}
 ```
 
-Response `200 OK` (or `204`) — empty body. Used by `Sidebar`'s delete action.
+Response `204 No Content` — empty body. Used by `Sidebar`'s delete action.
 
 ---
 
@@ -144,8 +149,16 @@ terminal state, all at once (waits for all stages to complete). The frontend
 uses the streaming endpoint instead; this one exists for non-streaming
 integrations.
 
-**Errors:** `400` (invalid body/UUID), `404` (not found), `409` (conversation
-closed — `code: "ErrConversationClosed"`), `503` (quorum not met), `500`.
+**Errors:** `400` (invalid body/UUID), `404` (not found), `409`, `503` (quorum
+not met), `500`. **409 has three distinct causes, discriminated only by the
+`error` message string — there is no `code` field on the wire (verified
+against backend source; a prior version of this doc claimed one existed —
+see gh#95):**
+| `error` message | Cause |
+|---|---|
+| `"conversation is closed"` | Message/answers sent to a closed conversation |
+| `"no pending clarification round"` | Round-N answers submitted with nothing pending |
+| `"clarification round already answered"` | Round-N answers submitted twice |
 
 ---
 
@@ -168,8 +181,13 @@ X-Accel-Buffering: no
 See [streaming.md](./streaming.md) for the full event sequence and payload
 shapes, including the Stage 0 clarification round-trip.
 
-**Errors:** `400` (invalid body/UUID), `404` (not found), `409` (conversation
-closed — `code: "ErrConversationClosed"`), `503` (quorum not met), `500`.
+**Errors:** `400` (invalid body/UUID), `404` (not found), `409`, `503` (quorum
+not met), `500` — all as pre-SSE HTTP responses (SSE headers are not yet
+written when these fire). The three 409 causes are the same as [Send Message
+(Blocking)](#send-message-blocking) above, discriminated by `error` message
+string, no `code` field. Pipeline-run failures that occur *after* SSE headers
+are written (quorum, chairman failure, storage) surface as a post-SSE `error`
+event instead of an HTTP status — see [streaming.md](./streaming.md#error).
 
 ---
 
@@ -214,6 +232,7 @@ closed — `code: "ErrConversationClosed"`), `503` (quorum not met), `500`.
   stage1: StageOneResult[]
   stage2: StageTwoResult[]
   stage3: StageThreeResult
+  metadata: Metadata          // persisted and returned as-is on replay — see gh#94
 }
 ```
 
@@ -252,7 +271,7 @@ strategies carry their Stage 2 content in `metadata` instead — see
 }
 ```
 
-### Metadata (ephemeral — streaming/blocking response only, not stored)
+### Metadata (persisted — same shape on streaming/blocking response and on replay, see gh#94)
 
 ```
 {
@@ -290,8 +309,13 @@ strategies carry their Stage 2 content in `metadata` instead — see
 
 The backend allows:
 - Origins: `http://localhost:5173`, `http://localhost:3000`
-- Methods: `GET`, `POST`, `OPTIONS`
+- Methods: `GET`, `POST`, `PATCH`, `DELETE`, `OPTIONS`
 - Headers: `Content-Type`
+
+**Known gap (backend-documented):** these are the frontend's former in-monorepo
+dev-server origins, carried over unchanged since extraction (2026-07-19).
+There is no origin covering a non-localhost deployment of this frontend, and
+no backend env var to add one.
 
 The Vite dev server also proxies `/api` → the backend (see `vite.config.js`),
 so `VITE_API_BASE` is only needed when serving the built frontend from a

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -16,27 +16,33 @@ line, demux by `type`. Additional fields depend on the event type.
 
 ## Event Sequence
 
+Verified against backend source (`internal/api/handler.go`'s `sendMessageStream`)
+— this is the complete, exhaustive list of event types the backend ever
+writes to the wire. **A prior version of this doc additionally listed
+`stage0_done`, `stage1_start`, `stage2_start`, and `stage3_start` as real
+events — none of them are ever emitted.** `stage0_done` is generated
+internally by the council runner but explicitly swallowed by the handler
+before reaching the client; the three `*_start` events never existed in the
+handler at all. See gh#96 for the frontend bug this produced (Stage 2/3
+loading spinners never render, since they only ever flip on via the
+non-existent `stage2_start`/`stage3_start`).
+
 ```
 data: {"type":"stage0_round_complete", ...}   ← optional, stream CLOSES here
   … client re-POSTs with {"answers":[...]} …
-data: {"type":"stage0_done"}                   ← Stage 1 follows on the same stream
-
-data: {"type":"stage1_start"}
 data: {"type":"stage1_complete", "data":[...StageOneResult]}
-data: {"type":"stage2_start"}
 data: {"type":"stage2_complete", "data":[...], "kind":"...", "metadata":{...}}
-data: {"type":"stage3_start"}
 data: {"type":"stage3_complete", "data":{...StageThreeResult}}
 data: {"type":"title_complete", "data":{"title":"..."}}   ← may be absent (30s timeout)
 data: {"type":"complete"}
 ```
 
 `stage0_*` only appears when the backend's clarification stage is enabled
-(`CLARIFICATION_MAX_ROUNDS` > 0 on the backend; off by default). `*_start`
-events exist purely to drive per-stage loading spinners in the UI — they
-carry no payload. `title_complete` runs concurrently with the pipeline and
-may arrive before or after `stage3_complete`; the frontend handles either
-ordering.
+(`CLARIFICATION_MAX_ROUNDS` > 0 on the backend; off by default). There is no
+event marking the Stage 0 → Stage 1 boundary — the stream simply continues
+straight into `stage1_complete` once clarification ends. `title_complete`
+runs concurrently with the pipeline and may arrive before or after
+`stage3_complete`; the frontend handles either ordering.
 
 ## Event Payloads
 
@@ -63,24 +69,6 @@ the body to continue.
 The frontend's `Stage0` component renders each question via `react-markdown`
 with a free-text answer box; "Skip" submits all-empty answers, which the
 backend treats as ending the clarification loop.
-
-### stage0_done
-
-Emitted when the clarification loop ends (chairman satisfied, round limit
-reached, or the user submitted all-empty answers). `stage1_start` /
-`stage1_complete` follow immediately on the same stream.
-
-```json
-{ "type": "stage0_done" }
-```
-
-### stage1_start / stage2_start / stage3_start
-
-No payload — flip the corresponding `loading.stageN` flag in the UI.
-
-```json
-{ "type": "stage1_start" }
-```
 
 ### stage1_complete
 
@@ -165,9 +153,11 @@ Wire-format invariants:
 ```
 
 May be absent if title generation exceeds a 30-second deadline. The title is
-derived from the first 50 **bytes** of the Stage 3 response — multi-byte
-UTF-8 characters may be cut mid-character. The frontend reloads the
-conversation list on this event.
+derived from the first 50 **runes** of the Stage 3 response — rune-safe
+truncation, multi-byte UTF-8 characters are never split (verified against
+backend source; a prior version of this doc claimed byte-based truncation
+that could cut mid-character — that was never accurate). The frontend
+reloads the conversation list on this event.
 
 ### complete
 
@@ -210,8 +200,14 @@ An unrecognised `kind` renders via a fallback view
 skips Stage 2 entirely — there is no strategy-specific metadata to show. The
 frontend's `RoleView` instead re-displays `stage1` (already present on the
 message) inside the Stage 2 slot, using each result's `label` directly as the
-role name (Generator/Critic/Verifier/Simplifier) — no `label_to_model` lookup,
-since role names aren't anonymised the way PeerReview's labels are.
+role name — no `label_to_model` lookup, since role names aren't anonymised the
+way PeerReview's labels are. `RoleView` is role-name-agnostic (renders
+whatever `label` the backend sends), so it's unaffected by role-set changes on
+the backend; only this doc's example names need to stay current. As of
+`vmm-rada@9dde00c` (2026-07-27) the role set is Creator/Critic/Verifier/
+Simplifier/DevilsAdvocate (renamed from Generator, DevilsAdvocate added —
+`internal/council/roles.go`), not the 4-role Generator/Critic/Verifier/
+Simplifier set this doc previously named.
 
 The frontend UI does not currently expose strategy selection — it always
 sends `council_type: "default"`. Which strategy that resolves to (and thus
@@ -250,18 +246,23 @@ while (true) {
 }
 ```
 
-`App.jsx`'s `makeStreamHandlers` maps each `eventType` to a state update:
+`App.jsx`'s `makeStreamHandlers` maps each `eventType` to a state update.
+**Rows marked `[dead]` register a handler for an event the backend never
+sends** (see the Event Sequence note above / gh#96) — harmless where the
+loading flag is already `true` from the message's initial state
+(`stage0_done`, `stage1_start`), a real gap where nothing else ever sets the
+flag (`stage2_start`, `stage3_start`):
 
 | Event | State change |
 |-------|---------------|
 | `stage0_round_complete` | `msg.pendingClarification = event.data`, clears `loading.stage0`/`loading.stage1` |
-| `stage0_done` | clears `pendingClarification`, `loading.stage1 = true` |
-| `stage1_start` | `loading.stage1 = true` |
+| `stage0_done` `[dead]` | clears `pendingClarification`, `loading.stage1 = true` |
+| `stage1_start` `[dead]` | `loading.stage1 = true` |
 | `stage1_complete` | `msg.stage1 = event.data`, `loading.stage1 = false` |
-| `stage2_start` | `loading.stage2 = true` |
+| `stage2_start` `[dead — real gap, see gh#96]` | `loading.stage2 = true` |
 | `stage2_round_complete` | appends into `msg.metadata.<debate\|delphi>.rounds`, sets `msg.stage2Kind` |
 | `stage2_complete` | `msg.stage2 = event.data`, `msg.stage2Kind = event.kind`, `msg.metadata = event.metadata`, `loading.stage2 = false` |
-| `stage3_start` | `loading.stage3 = true` |
+| `stage3_start` `[dead — real gap, see gh#96]` | `loading.stage3 = true` |
 | `stage3_complete` | `msg.stage3 = event.data`, `loading.stage3 = false`, marks conversation closed, reloads conversation list |
 | `title_complete` | reloads conversation list |
 | `complete` | reloads conversation list, `isLoading = false` |

--- a/src/components/Stage2.jsx
+++ b/src/components/Stage2.jsx
@@ -633,8 +633,9 @@ function DelphiView({ delphi, isLoading }) {
 // "Stage 2 is skipped; a minimal Stage2CompleteData event is emitted for SSE
 // compatibility"), so there is no strategy-specific metadata to show here.
 // The per-role content lives entirely in `stage1`, where `label` is the role
-// name (Generator/Critic/Verifier/Simplifier) rather than an anonymised
-// "Response A" — no de-anonymisation lookup needed, unlike PeerRankingView.
+// name (e.g. Creator/Critic/Verifier/Simplifier/DevilsAdvocate — role-agnostic,
+// this view renders whatever label the backend sends) rather than an
+// anonymised "Response A" — no de-anonymisation lookup needed, unlike PeerRankingView.
 // Re-displaying stage1 content inside the Stage 2 slot mirrors MoaView's
 // "Layer 1 — Proposers" panel, which does the same for MixtureOfAgents.
 function RoleRow({ result }) {


### PR DESCRIPTION
## Summary

Field-by-field diff against the backend's `docs/api.md` (cloned locally at `~/wrk/projects/vmm-rada/vmm-rada`), cross-checked against actual handler/storage source rather than trusting either doc's prose.

**Corrected divergences:**
- `metadata` IS persisted and returned on `GET /api/conversations/{id}` (verified: `SaveAssistantMessage` marshals the full `AssistantMessage` struct including `Metadata`, no `omitempty`/`-` tag). The prior "ephemeral, not returned" claim was never true.
- CORS methods list was missing `PATCH` and `DELETE` (backend allows both; frontend actually uses both).
- 409 errors: the `code: "ErrConversationClosed"` claim was fictional — grepped the entire backend API/storage layer, zero matches for any `code` field. Documented the three real 409 causes, discriminated by `error` message string only.
- `title_complete` truncation: backend truncates by **rune** (rune-safe), not by byte as previously claimed.
- Removed four fictional SSE events (`stage0_done`, `stage1_start`, `stage2_start`, `stage3_start`) from the documented sequence — verified against the full `sendMessageStream` handler that none are ever written to the wire.
- RoleBased's role set is now Creator/Critic/Verifier/Simplifier/DevilsAdvocate (renamed from Generator, DevilsAdvocate added, `vmm-rada@9dde00c`) — updated the one stale reference in `Stage2.jsx`'s `RoleView` comment (comment-only, `RoleView` itself is role-name-agnostic).
- `DELETE /api/conversations/{id}` always returns `204`, not "200 (or 204)".

**Security review flag** (not introduced by this PR — existing backend behavior, previously mis-documented as ephemeral): `label_to_model` is retrievable indefinitely via `GET`, and this project has no auth layer. Added a note for awareness; the trade-off decision is out of scope for a frontend-docs fix.

**Filed 3 follow-up issues** for real behavioral bugs this diff surfaced (deliberately not fixed in this docs-only PR):
- #94 `deriveStage2Kind` ignores `metadata.council_type` on replay — mis-renders 6 of 7 strategies as `PeerRankingView` after reload
- #95 409 classification checks a `code` field the backend never sends — misclassifies 2 of 3 real 409 causes
- #96 `stage2_start`/`stage3_start` don't exist — Stage 2/3 loading spinners never render

Closes #77

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (106/106, unaffected — docs + comment-only change)
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)