### PR TITLE
⚖️ fix(app): derive stage2Kind from persisted shape, not council_type name

### DIFF
--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -18,9 +18,13 @@ contain JSON payloads.
   object that was present at streaming/blocking-response time, byte-for-byte
   (`Conversation.Messages` is stored as raw JSON). This corrects a prior
   version of this doc that claimed metadata was ephemeral and stripped on
-  replay — that claim was never true against current backend behavior. See
-  gh#94 for the frontend bug this false assumption produced (`deriveStage2Kind`
-  ignores the now-confirmed-present `metadata.council_type` on replay).
+  replay — that claim was never true against current backend behavior. This
+  false assumption previously caused `App.jsx`'s `deriveStage2Kind` to
+  mis-render 6 of 7 strategies as `PeerRankingView` on replay — fixed (gh#94)
+  by inferring `kind` from Metadata's strategy-specific sub-object presence
+  rather than from `council_type`, since custom-named registrations sharing
+  a strategy (e.g. `"factual-majority"` / `"creative-majority"`, both
+  `Strategy: Majority`) make a name-based lookup unreliable.
   **Security note:** this means `label_to_model` (which model produced which
   response) is retrievable indefinitely via `GET /api/conversations/{id}`,
   not just during the live session — this project has no auth layer, so

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,20 +15,31 @@ function isConversationClosedError(err) {
   return err.code === 'ErrConversationClosed' || err.code === 'conversation_closed';
 }
 
-// Maps a persisted council_type (or a strategy-emitted Stage 2 kind) to the
-// kind value the Stage2 dispatcher expects. Today only PeerReview is
-// persistable, so "default" → "peer_ranking". Future strategies extend the
-// switch when their registrations begin persisting. Empty / whitespace / null
-// inputs all collapse to "peer_ranking" — the safe pre-this-PR default.
-function deriveStage2Kind(councilType) {
-  const ct = (councilType ?? '').trim();
-  if (!ct) return 'peer_ranking';
-  switch (ct) {
-    case 'default':
-      return 'peer_ranking';
-    default:
-      return 'peer_ranking';
-  }
+// Derives the Stage2 dispatcher's `kind` value from a replayed message's
+// persisted shape. The backend does not persist `kind` itself, but
+// Metadata's strategy-specific sub-object presence (vote_tally, rank_refine,
+// debate, moa_aggregator, delphi — each `omitempty` on the backend,
+// internal/council/types.go) unambiguously identifies 5 of 7 kinds
+// regardless of what council_type *name* was used to register the strategy.
+// A name lookup (e.g. "majority" -> "vote_tally") is not robust: the backend
+// supports multiple custom-named registrations sharing one Strategy (its own
+// docs give "factual-majority" and "creative-majority", both
+// Strategy: Majority) — shape inference sidesteps that entirely.
+//
+// `peer_ranking` and `role_stub` are the two kinds with no distinguishing
+// metadata sub-object — the tiebreaker is stage2 array emptiness: PeerReview
+// always produces a non-empty StageTwoResult[] (every model's response gets
+// peer-reviewed), RoleBased's stage2 is always `[]` (Stage 2 is skipped
+// entirely for that strategy).
+function deriveStage2Kind(stage2, metadata) {
+  if (!metadata) return 'peer_ranking';
+  if (metadata.vote_tally) return 'vote_tally';
+  if (metadata.rank_refine) return 'rank_refine';
+  if (metadata.debate) return 'debate_round';
+  if (metadata.moa_aggregator) return 'moa_aggregator';
+  if (metadata.delphi) return 'delphi_round';
+  const hasRankings = Array.isArray(stage2) && stage2.length > 0;
+  return hasRankings ? 'peer_ranking' : 'role_stub';
 }
 
 // normaliseStage2Kind treats null/undefined/empty/whitespace as missing and
@@ -110,14 +121,13 @@ function App() {
         })
         .map((msg) => {
           if (msg.role !== 'assistant') return msg;
-          // AssistantMessage doesn't persist Kind, so derive stage2Kind from
-          // metadata.council_type for replay. Falls back to "peer_ranking" for
-          // missing council_type — matches the pre-this-PR rendering default.
+          // AssistantMessage doesn't persist `kind` itself, so derive
+          // stage2Kind from the persisted stage2/metadata shape for replay.
           return {
             loading: { stage0: false, stage1: false, stage2: false, stage3: false },
             error: null,
             pendingClarification: null,
-            stage2Kind: deriveStage2Kind(msg.metadata?.council_type),
+            stage2Kind: deriveStage2Kind(msg.stage2, msg.metadata),
             ...msg,
           };
         });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -374,3 +374,175 @@ describe('409 ErrConversationClosed on handleAnswerSubmit', () => {
     );
   });
 });
+
+// ── deriveStage2Kind on replay (loadConversation) ───────────────────────────
+// AssistantMessage doesn't persist `kind` itself (confirmed against backend
+// source — see docs/api-contract.md). App.jsx must infer it from the
+// persisted stage2/metadata shape. Regression coverage for gh#94: a prior
+// implementation collapsed every non-default council_type to "peer_ranking"
+// on replay, mis-rendering 6 of 7 strategies after a page reload.
+
+describe('loadConversation derives stage2Kind from persisted shape', () => {
+  it('renders RoleView (not PeerRankingView) for a replayed role_stub conversation', async () => {
+    mockApi.listConversations.mockResolvedValue([
+      { id: 'conv-1', title: 'One', created_at: '2026-05-02T12:00:00Z' },
+    ]);
+    mockApi.getConversation.mockResolvedValue(
+      makeConversation({
+        messages: [
+          { role: 'user', content: 'hi' },
+          {
+            role: 'assistant',
+            stage1: [
+              { label: 'Creator', model: 'openai/gpt-4o', content: 'creator answer' },
+              { label: 'Critic', model: 'anthropic/claude-sonnet-4-5', content: 'critic answer' },
+            ],
+            // role_stub: stage2 is always empty and metadata carries no
+            // strategy-specific sub-object — the same shape a naive
+            // council_type-name lookup can't distinguish from peer_ranking.
+            stage2: [],
+            stage3: { content: 'final', model: 'openai/gpt-4o' },
+            metadata: { council_type: 'role-based', aggregate_rankings: [], consensus_w: 1.0 },
+          },
+        ],
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(await screen.findByRole('button', { name: /One/ }));
+
+    expect(await screen.findByText(/Stage 2: Role Perspectives/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Stage 2: Peer Rankings/i)).not.toBeInTheDocument();
+  });
+
+  it('renders PeerRankingView for a replayed peer_ranking conversation (non-empty stage2)', async () => {
+    mockApi.listConversations.mockResolvedValue([
+      { id: 'conv-1', title: 'One', created_at: '2026-05-02T12:00:00Z' },
+    ]);
+    mockApi.getConversation.mockResolvedValue(
+      makeConversation({
+        messages: [
+          { role: 'user', content: 'hi' },
+          {
+            role: 'assistant',
+            stage1: [{ label: 'Response A', model: 'openai/gpt-4o', content: 'answer a' }],
+            stage2: [{ reviewer_label: 'Response A', rankings: ['Response A'] }],
+            stage3: { content: 'final', model: 'openai/gpt-4o' },
+            metadata: {
+              council_type: 'default',
+              label_to_model: { 'Response A': 'openai/gpt-4o' },
+              aggregate_rankings: [{ model: 'openai/gpt-4o', score: 1.0 }],
+              consensus_w: 1.0,
+            },
+          },
+        ],
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(await screen.findByRole('button', { name: /One/ }));
+
+    expect(await screen.findByText(/Stage 2: Peer Rankings/i)).toBeInTheDocument();
+  });
+
+  it('renders VoteTallyView for a replayed custom-named Majority registration', async () => {
+    // Regression guard for the specific gap gh#94 was filed about: a
+    // council_type *name* lookup breaks on custom-named registrations
+    // sharing a strategy (backend docs example: "factual-majority" /
+    // "creative-majority" both Strategy: Majority). Shape inference doesn't
+    // care what the name is.
+    mockApi.listConversations.mockResolvedValue([
+      { id: 'conv-1', title: 'One', created_at: '2026-05-02T12:00:00Z' },
+    ]);
+    mockApi.getConversation.mockResolvedValue(
+      makeConversation({
+        messages: [
+          { role: 'user', content: 'hi' },
+          {
+            role: 'assistant',
+            stage1: [{ label: 'Response A', model: 'openai/gpt-4o', content: 'answer a' }],
+            stage2: [],
+            stage3: { content: 'final', model: 'openai/gpt-4o' },
+            metadata: {
+              council_type: 'factual-majority',
+              aggregate_rankings: [],
+              consensus_w: 0,
+              vote_tally: {
+                winner_label: 'Response A',
+                clusters: [{ members: ['Response A'], representative: 'answer a', votes: 1 }],
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(await screen.findByRole('button', { name: /One/ }));
+
+    expect(await screen.findByText(/Stage 2: Vote Tally/i)).toBeInTheDocument();
+  });
+
+  it('renders DebateView for a replayed MultiAgentDebate conversation', async () => {
+    mockApi.listConversations.mockResolvedValue([
+      { id: 'conv-1', title: 'One', created_at: '2026-05-02T12:00:00Z' },
+    ]);
+    mockApi.getConversation.mockResolvedValue(
+      makeConversation({
+        messages: [
+          { role: 'user', content: 'hi' },
+          {
+            role: 'assistant',
+            stage1: [{ label: 'Response A', model: 'openai/gpt-4o', content: 'answer a' }],
+            stage2: [],
+            stage3: { content: 'final', model: 'openai/gpt-4o' },
+            metadata: {
+              council_type: 'debate',
+              aggregate_rankings: [],
+              consensus_w: 0,
+              debate: {
+                rounds: [{ round: 1, revisions: [{ label: 'Response A', content: 'revision 1' }] }],
+                final_round: 1,
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(await screen.findByRole('button', { name: /One/ }));
+
+    expect(await screen.findByText(/Stage 2: Debate/i)).toBeInTheDocument();
+  });
+
+  it('falls back to peer_ranking when metadata is entirely absent (old-backend safety net)', async () => {
+    mockApi.listConversations.mockResolvedValue([
+      { id: 'conv-1', title: 'One', created_at: '2026-05-02T12:00:00Z' },
+    ]);
+    mockApi.getConversation.mockResolvedValue(
+      makeConversation({
+        messages: [
+          { role: 'user', content: 'hi' },
+          {
+            role: 'assistant',
+            stage1: [{ label: 'Response A', model: 'openai/gpt-4o', content: 'answer a' }],
+            stage2: [{ reviewer_label: 'Response A', rankings: ['Response A'] }],
+            stage3: { content: 'final', model: 'openai/gpt-4o' },
+            metadata: null,
+          },
+        ],
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(await screen.findByRole('button', { name: /One/ }));
+
+    expect(await screen.findByText(/Stage 2: Peer Rankings/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- `src/App.jsx`: `deriveStage2Kind` unconditionally collapsed every strategy to `"peer_ranking"` on conversation replay — real bug affecting 6 of 7 deliberation strategies after a page reload (found while diffing backend docs for #77).
- Considered a `council_type` name lookup (the fix the issue's own acceptance criteria suggested) but rejected it: backend docs confirm multiple custom-named registrations can share one `Strategy` (`"factual-majority"` / `"creative-majority"`, both `Strategy: Majority`) — a name switch would silently misclassify any custom-named registration.
- Implemented shape-based inference instead: derive `kind` from which `Metadata` sub-object is actually present (`vote_tally`/`rank_refine`/`debate`/`moa_aggregator`/`delphi` are each `omitempty` on the backend — unambiguous when present). `peer_ranking` and `role_stub` share the same "no sub-object" shape; the tiebreaker is `stage2` array emptiness (PeerReview always produces a non-empty `StageTwoResult[]`, RoleBased's is always `[]`).
- 5 new regression tests: `role_stub`, `peer_ranking`, a **custom-named Majority registration** (the exact case a name lookup would break on), `MultiAgentDebate`, and the metadata-absent fallback.
- `docs/api-contract.md`: reconciled the `gh#94` note now that the bug is fixed.

Closes #94

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (111/111, up from 106/106)
- [ ] No console errors
- [ ] Manual smoke test: create a RoleBased/Majority/Debate conversation against the real backend, reload the page, confirm the correct Stage 2 view renders (not Peer Rankings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)