### PR TITLE
⚖️ fix(app): derive Stage 2/3 loading from prior stage completion

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -23,9 +23,9 @@ writes to the wire. **A prior version of this doc additionally listed
 events — none of them are ever emitted.** `stage0_done` is generated
 internally by the council runner but explicitly swallowed by the handler
 before reaching the client; the three `*_start` events never existed in the
-handler at all. See gh#96 for the frontend bug this produced (Stage 2/3
-loading spinners never render, since they only ever flip on via the
-non-existent `stage2_start`/`stage3_start`).
+handler at all. `App.jsx` no longer registers handlers for any of the four
+(gh#96) — Stage 2/3 loading now derives from the prior stage's `*_complete`
+event instead of waiting for a `*_start` event that was never coming.
 
 ```
 data: {"type":"stage0_round_complete", ...}   ← optional, stream CLOSES here
@@ -247,22 +247,19 @@ while (true) {
 ```
 
 `App.jsx`'s `makeStreamHandlers` maps each `eventType` to a state update.
-**Rows marked `[dead]` register a handler for an event the backend never
-sends** (see the Event Sequence note above / gh#96) — harmless where the
-loading flag is already `true` from the message's initial state
-(`stage0_done`, `stage1_start`), a real gap where nothing else ever sets the
-flag (`stage2_start`, `stage3_start`):
+There are no handlers for `stage0_done`/`stage1_start`/`stage2_start`/
+`stage3_start` — the backend never sends them (see the Event Sequence note
+above). Stage 2/3 loading is derived from the *prior* stage's `*_complete`
+event instead of waiting for a `*_start` event that was never coming (fixed
+in gh#96 — previously `loading.stage2`/`loading.stage3` had no handler
+setting them `true` at all, so the Stage 2/3 spinners never rendered):
 
 | Event | State change |
 |-------|---------------|
 | `stage0_round_complete` | `msg.pendingClarification = event.data`, clears `loading.stage0`/`loading.stage1` |
-| `stage0_done` `[dead]` | clears `pendingClarification`, `loading.stage1 = true` |
-| `stage1_start` `[dead]` | `loading.stage1 = true` |
-| `stage1_complete` | `msg.stage1 = event.data`, `loading.stage1 = false` |
-| `stage2_start` `[dead — real gap, see gh#96]` | `loading.stage2 = true` |
+| `stage1_complete` | `msg.stage1 = event.data`, `loading.stage1 = false`, **`loading.stage2 = true`** (Stage 2 begins immediately, no `stage2_start` event exists) |
 | `stage2_round_complete` | appends into `msg.metadata.<debate\|delphi>.rounds`, sets `msg.stage2Kind` |
-| `stage2_complete` | `msg.stage2 = event.data`, `msg.stage2Kind = event.kind`, `msg.metadata = event.metadata`, `loading.stage2 = false` |
-| `stage3_start` `[dead — real gap, see gh#96]` | `loading.stage3 = true` |
+| `stage2_complete` | `msg.stage2 = event.data`, `msg.stage2Kind = event.kind`, `msg.metadata = event.metadata`, `loading.stage2 = false`, **`loading.stage3 = true`** (Stage 3 begins immediately, no `stage3_start` event exists) |
 | `stage3_complete` | `msg.stage3 = event.data`, `loading.stage3 = false`, marks conversation closed, reloads conversation list |
 | `title_complete` | reloads conversation list |
 | `complete` | reloads conversation list, `isLoading = false` |

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -236,17 +236,17 @@ function App() {
       });
       setIsLoading(false);
     },
-    stage0_done: () => updateLast((msg) => {
-      msg.pendingClarification = null;
-      msg.loading.stage0 = false;
-      msg.loading.stage1 = true;
-    }),
-    stage1_start: () => updateLast((msg) => { msg.loading.stage1 = true; }),
     stage1_complete: (event) => updateLast((msg) => {
       msg.stage1 = event.data;
       msg.loading.stage1 = false;
+      // The backend never emits a stage2_start event — Stage 2 begins
+      // immediately once Stage 1 completes (verified against handler.go's
+      // sendMessageStream). Flip the spinner here instead of waiting for an
+      // event that doesn't exist. stage2_complete always fires eventually,
+      // even for strategies that skip real Stage 2 work (RoleBased emits an
+      // immediate stub event), so this can't get stuck true.
+      msg.loading.stage2 = true;
     }),
-    stage2_start: () => updateLast((msg) => { msg.loading.stage2 = true; }),
     // Per-round events from multi-round strategies (MultiAgentDebate, Delphi).
     // Single source of truth per strategy: msg.metadata.<kind-pointer>.rounds.
     // Each event APPENDS its round's transcript subset to the running list;
@@ -263,8 +263,10 @@ function App() {
       // includes the canonical debate transcript (with dropouts) for replay.
       msg.metadata = event.metadata;
       msg.loading.stage2 = false;
+      // Same reasoning as stage1_complete above — no stage3_start event
+      // exists; Stage 3 (Chairman synthesis) begins immediately.
+      msg.loading.stage3 = true;
     }),
-    stage3_start: () => updateLast((msg) => { msg.loading.stage3 = true; }),
     stage3_complete: (event) => {
       updateLast((msg) => {
         msg.stage3 = event.data;

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -375,6 +375,113 @@ describe('409 ErrConversationClosed on handleAnswerSubmit', () => {
   });
 });
 
+// ── Stage 2/3 loading spinners (gh#96) ──────────────────────────────────────
+// The backend never emits stage2_start/stage3_start (verified against
+// handler.go). Prior to this fix, loading.stage2/loading.stage3 had no
+// handler ever setting them true, so the Stage 2 and Stage 3 spinners never
+// rendered — content just popped in abruptly on *_complete. Regression
+// coverage: assert the spinners actually appear, derived from the prior
+// stage's *_complete event.
+
+describe('Stage 2/3 loading spinners derived from prior stage completion', () => {
+  it('shows the Stage 2 spinner immediately after stage1_complete', async () => {
+    mockApi.listConversations.mockResolvedValue([
+      { id: 'conv-1', title: 'One', created_at: '2026-05-02T12:00:00Z' },
+    ]);
+    mockApi.getConversation.mockResolvedValue(makeConversation());
+    mockApi.sendMessageStream.mockImplementation(
+      scriptedStream([
+        ['stage1_complete', { type: 'stage1_complete', data: [{ label: 'Response A', model: 'openai/gpt-4o', content: 'a' }] }],
+      ]),
+    );
+
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: /One/ }));
+    const input = await screen.findByPlaceholderText(/Ask a question/i);
+    await waitFor(() => expect(input).not.toBeDisabled());
+
+    await user.type(input, 'hello');
+    await user.click(screen.getByRole('button', { name: /Send/i }));
+
+    // Stage2 defaults to the peer_ranking spinner until a kind arrives.
+    expect(await screen.findByText(/Running peer rankings…/i)).toBeInTheDocument();
+  });
+
+  it('clears the Stage 2 spinner and shows the Stage 3 spinner after stage2_complete', async () => {
+    mockApi.listConversations.mockResolvedValue([
+      { id: 'conv-1', title: 'One', created_at: '2026-05-02T12:00:00Z' },
+    ]);
+    mockApi.getConversation.mockResolvedValue(makeConversation());
+    mockApi.sendMessageStream.mockImplementation(
+      scriptedStream([
+        ['stage1_complete', { type: 'stage1_complete', data: [{ label: 'Response A', model: 'openai/gpt-4o', content: 'a' }] }],
+        [
+          'stage2_complete',
+          {
+            type: 'stage2_complete',
+            kind: 'peer_ranking',
+            data: [{ reviewer_label: 'Response A', rankings: ['Response A'] }],
+            metadata: { label_to_model: { 'Response A': 'openai/gpt-4o' }, aggregate_rankings: [], consensus_w: 1 },
+          },
+        ],
+      ]),
+    );
+
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: /One/ }));
+    const input = await screen.findByPlaceholderText(/Ask a question/i);
+    await waitFor(() => expect(input).not.toBeDisabled());
+
+    await user.type(input, 'hello');
+    await user.click(screen.getByRole('button', { name: /Send/i }));
+
+    expect(await screen.findByText(/Synthesising final answer/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Running peer rankings…/i)).not.toBeInTheDocument();
+  });
+
+  it('clears the Stage 3 spinner after stage3_complete', async () => {
+    mockApi.listConversations.mockResolvedValue([
+      { id: 'conv-1', title: 'One', created_at: '2026-05-02T12:00:00Z' },
+    ]);
+    mockApi.getConversation.mockResolvedValue(makeConversation());
+    mockApi.sendMessageStream.mockImplementation(
+      scriptedStream([
+        ['stage1_complete', { type: 'stage1_complete', data: [{ label: 'Response A', model: 'openai/gpt-4o', content: 'a' }] }],
+        [
+          'stage2_complete',
+          {
+            type: 'stage2_complete',
+            kind: 'peer_ranking',
+            data: [{ reviewer_label: 'Response A', rankings: ['Response A'] }],
+            metadata: { label_to_model: { 'Response A': 'openai/gpt-4o' }, aggregate_rankings: [], consensus_w: 1 },
+          },
+        ],
+        [
+          'stage3_complete',
+          { type: 'stage3_complete', data: { content: 'final answer', model: 'openai/gpt-4o' } },
+        ],
+      ]),
+    );
+
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: /One/ }));
+    const input = await screen.findByPlaceholderText(/Ask a question/i);
+    await waitFor(() => expect(input).not.toBeDisabled());
+
+    await user.type(input, 'hello');
+    await user.click(screen.getByRole('button', { name: /Send/i }));
+
+    expect(await screen.findByText('final answer')).toBeInTheDocument();
+    expect(screen.queryByText(/Synthesising final answer/i)).not.toBeInTheDocument();
+  });
+});
+
 // ── deriveStage2Kind on replay (loadConversation) ───────────────────────────
 // AssistantMessage doesn't persist `kind` itself (confirmed against backend
 // source — see docs/api-contract.md). App.jsx must infer it from the


### PR DESCRIPTION
## Summary
- `stage2_start`/`stage3_start` don't exist on the backend wire (confirmed against the full `sendMessageStream` handler — found while diffing docs for #77). `loading.stage2`/`loading.stage3` had no other handler ever setting them `true`, so the Stage 2 and Stage 3 spinners never rendered — content popped in abruptly after several seconds of apparent nothing happening.
- Removed 4 dead handlers (`stage0_done`, `stage1_start`, `stage2_start`, `stage3_start` — none ever fire; the dispatch pattern already no-ops on unregistered event types).
- Derived the loading flip from the **prior** stage's `*_complete` event instead: `stage1_complete` sets `loading.stage2 = true` (Stage 2 begins immediately — even RoleBased's stub event fires promptly, so this can't get stuck); `stage2_complete` sets `loading.stage3 = true` analogously.
- Applies to both `handleSendMessage` and `handleAnswerSubmit` — both share `makeStreamHandlers`, so the fix covers the clarification-answer path too without a separate change.
- 3 new regression tests asserting the spinners actually appear/clear at the right points.
- `docs/streaming.md`'s frontend-implementation table updated to show the fix (was already annotated with the gap in #97; now shows resolution, not just the gap).

Closes #96

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (114/114, up from 111/111)
- [ ] No console errors
- [ ] Manual smoke test: run a real deliberation against the backend, confirm the Stage 2 and Stage 3 spinners visibly appear during their actual wait time (not just content popping in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)