### PR TITLE
⚖️ fix(api): derive 409 error code from message string, not a nonexistent field

### DIFF
--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -162,13 +162,15 @@ integrations.
 **Errors:** `400` (invalid body/UUID), `404` (not found), `409`, `503` (quorum
 not met), `500`. **409 has three distinct causes, discriminated only by the
 `error` message string — there is no `code` field on the wire (verified
-against backend source; a prior version of this doc claimed one existed —
-see gh#95):**
-| `error` message | Cause |
-|---|---|
-| `"conversation is closed"` | Message/answers sent to a closed conversation |
-| `"no pending clarification round"` | Round-N answers submitted with nothing pending |
-| `"clarification round already answered"` | Round-N answers submitted twice |
+against backend source; a prior version of this doc claimed one existed).**
+`src/api.js`'s `ApiError.code` is derived client-side from the message string
+(gh#95) — a nonexistent-code fallback previously misclassified the other two
+causes as conversation-closed:
+| `error` message (wire) | Frontend `ApiError.code` | Cause |
+|---|---|---|
+| `"conversation is closed"` | `conversation_closed` | Message/answers sent to a closed conversation |
+| `"no pending clarification round"` | `no_pending_clarification_round` | Round-N answers submitted with nothing pending |
+| `"clarification round already answered"` | `clarification_round_already_answered` | Round-N answers submitted twice |
 
 ---
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,13 +6,14 @@ import './App.css';
 
 // isConversationClosedError reports whether an error thrown from the API
 // adapter indicates the conversation was closed before this request finished.
-// Backend (vmm-rada@0aa5178, PR #310) returns 409 with `code: ErrConversationClosed`
-// for clarification round-N answers on a closed conversation. We also accept
-// the kebab-case form some intermediate layers emit.
+// `error.code` is derived client-side in src/api.js from the backend's exact
+// message string ("conversation is closed") — the backend has no wire-level
+// code field. A prior version of this check accepted any 409 as
+// conversation-closed, which misclassified the two other real 409 causes
+// (no pending clarification round; round already answered) as closure too.
 function isConversationClosedError(err) {
   if (!(err instanceof ApiError)) return false;
-  if (err.status !== 409) return false;
-  return err.code === 'ErrConversationClosed' || err.code === 'conversation_closed';
+  return err.status === 409 && err.code === 'conversation_closed';
 }
 
 // Derives the Stage2 dispatcher's `kind` value from a replayed message's

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -249,21 +249,22 @@ describe('loadConversation propagates closed flag', () => {
   });
 });
 
-// ── 409 ErrConversationClosed catch paths ─────────────────────────────────
-// Per backend vmm-rada@0aa5178 (PR #310), submitting a message or clarification
-// answers to a closed conversation returns 409 with
-// `code: ErrConversationClosed`. App.jsx must surface this as a typed error on
-// the assistant message and mark the conversation closed, instead of rolling
-// back the optimistic user/assistant pair.
+// ── 409 catch paths ──────────────────────────────────────────────────────
+// `error.code` is derived client-side in src/api.js from the backend's exact
+// message string — there is no wire-level code field (verified against
+// internal/api/handler.go). isConversationClosedError must only match
+// `code: 'conversation_closed'`, not any 409 (gh#95 — a prior version
+// treated every 409 as conversation-closed, misclassifying the other two
+// real 409 causes).
 
-describe('409 ErrConversationClosed on handleSendMessage', () => {
+describe('409 conversation_closed on handleSendMessage', () => {
   it('surfaces the typed error on the assistant message and marks closed', async () => {
     mockApi.listConversations.mockResolvedValue([
       { id: 'conv-1', title: 'One', created_at: '2026-05-02T12:00:00Z' },
     ]);
     mockApi.getConversation.mockResolvedValue(makeConversation());
     mockApi.sendMessageStream.mockRejectedValueOnce(
-      new ApiError({ code: 'ErrConversationClosed', status: 409, message: 'conversation closed' }),
+      new ApiError({ code: 'conversation_closed', status: 409, message: 'conversation is closed' }),
     );
 
     const user = userEvent.setup();
@@ -316,10 +317,45 @@ describe('409 ErrConversationClosed on handleSendMessage', () => {
       screen.queryByText(/This conversation has been closed/i),
     ).not.toBeInTheDocument();
   });
+
+  it('does not treat a round-conflict 409 as conversation-closed (gh#95 regression)', async () => {
+    mockApi.listConversations.mockResolvedValue([
+      { id: 'conv-1', title: 'One', created_at: '2026-05-02T12:00:00Z' },
+    ]);
+    mockApi.getConversation.mockResolvedValue(makeConversation());
+    mockApi.sendMessageStream.mockRejectedValueOnce(
+      new ApiError({
+        code: 'clarification_round_already_answered',
+        status: 409,
+        message: 'clarification round already answered',
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: /One/ }));
+
+    const input = await screen.findByPlaceholderText(/Ask a question/i);
+    await waitFor(() => expect(input).not.toBeDisabled());
+
+    await user.type(input, 'hello');
+    await user.click(screen.getByRole('button', { name: /Send/i }));
+
+    // Not misclassified as conversation-closed: rolls back like any other
+    // non-conversation-closed error, and the input re-enables (not stuck
+    // disabled with the closed-state copy).
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/Ask a question/i)).not.toBeDisabled(),
+    );
+    expect(
+      screen.queryByText(/This conversation has been closed/i),
+    ).not.toBeInTheDocument();
+  });
 });
 
-describe('409 ErrConversationClosed on handleAnswerSubmit', () => {
-  it('surfaces the typed error on the assistant message and marks closed', async () => {
+describe('409 handling on handleAnswerSubmit', () => {
+  it('surfaces the typed error on the assistant message and marks closed for conversation_closed', async () => {
     mockApi.listConversations.mockResolvedValue([
       { id: 'conv-1', title: 'One', created_at: '2026-05-02T12:00:00Z' },
     ]);
@@ -342,7 +378,7 @@ describe('409 ErrConversationClosed on handleAnswerSubmit', () => {
       )
       // Second call: the user submits answers, conversation is now closed.
       .mockRejectedValueOnce(
-        new ApiError({ code: 'ErrConversationClosed', status: 409, message: 'conversation closed' }),
+        new ApiError({ code: 'conversation_closed', status: 409, message: 'conversation is closed' }),
       );
 
     const user = userEvent.setup();
@@ -372,6 +408,52 @@ describe('409 ErrConversationClosed on handleAnswerSubmit', () => {
     await waitFor(() =>
       expect(screen.getByPlaceholderText(/conversation has ended/i)).toBeDisabled(),
     );
+  });
+
+  it('does not treat "clarification round already answered" as conversation-closed (gh#95 regression)', async () => {
+    // This is the realistic path where the round-conflict 409s actually
+    // occur — a double-submit of the same clarification round.
+    mockApi.listConversations.mockResolvedValue([
+      { id: 'conv-1', title: 'One', created_at: '2026-05-02T12:00:00Z' },
+    ]);
+    mockApi.getConversation.mockResolvedValue(makeConversation());
+    mockApi.sendMessageStream
+      .mockImplementationOnce(
+        scriptedStream([
+          [
+            'stage0_round_complete',
+            { type: 'stage0_round_complete', data: { round: 1, questions: [{ id: 'q1', text: 'Which framework?' }] } },
+          ],
+        ]),
+      )
+      .mockRejectedValueOnce(
+        new ApiError({
+          code: 'clarification_round_already_answered',
+          status: 409,
+          message: 'clarification round already answered',
+        }),
+      );
+
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: /One/ }));
+
+    const input = await screen.findByPlaceholderText(/Ask a question/i);
+    await waitFor(() => expect(input).not.toBeDisabled());
+
+    await user.type(input, 'help me choose');
+    await user.click(screen.getByRole('button', { name: /Send/i }));
+
+    const answerTextarea = await screen.findByPlaceholderText(/Your answer/i);
+    await user.type(answerTextarea, 'react');
+    await user.click(screen.getByRole('button', { name: /Submit answers/i }));
+
+    // Not misclassified: no "conversation has been closed" copy, and the
+    // conversation is not marked closed.
+    await waitFor(() => {
+      expect(screen.queryByText(/This conversation has been closed/i)).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/src/api.js
+++ b/src/api.js
@@ -26,12 +26,20 @@ const API_BASE = (() => {
 })();
 
 // ApiError is the typed error thrown by the API adapter for non-2xx responses.
-// `code` is the backend's machine-readable identifier (e.g. "ErrConversationClosed",
-// "conversation_closed" from vmm-rada@0aa5178 / PR #310). `status` is the HTTP
-// status code. `message` is the human-readable message from the backend when
-// available, falling back to the original generic message. Per architectural
-// rule 2 (adapter boundary), raw HTTP status codes do not leak past this module;
-// App.jsx dispatches on `error.code` / `error instanceof ApiError` instead.
+// `status` is the HTTP status code. `message` is the human-readable message
+// from the backend when available, falling back to the original generic
+// message. Per architectural rule 2 (adapter boundary), raw HTTP status codes
+// do not leak past this module; App.jsx dispatches on `error.code` /
+// `error instanceof ApiError` instead.
+//
+// `code` is derived entirely client-side from `message` via KNOWN_ERROR_CODES
+// below — the backend has no `code` field on the wire (verified exhaustively
+// against internal/api/handler.go's writeError, which only ever writes
+// {"error": msg}; see docs/api-contract.md). A prior version of this class
+// forwarded a nonexistent `body.code` and, when absent, treated *any* 409 as
+// conversation-closed — that fallback misclassified the two other real 409
+// causes ("no pending clarification round", "clarification round already
+// answered") as conversation-closed too.
 export class ApiError extends Error {
   constructor({ code, status, message }) {
     super(message);
@@ -41,34 +49,38 @@ export class ApiError extends Error {
   }
 }
 
-// handleErrorResponse reads the JSON body (if any) for a non-2xx response and
-// returns a typed `ApiError`. For 409 specifically (the only status the
-// backend currently marks as a distinct machine-readable code) we forward the
-// backend's `code` and `message` so App.jsx can branch on it. For other
-// statuses we keep the existing generic message but still surface `status` so
-// downstream code can inspect it if needed.
-//
-// When the backend returns 409 with an empty/non-JSON body (e.g. a Go panic
-// returns an empty 409), we fall back to a synthetic code so App.jsx can still
-// recognise the conversation-closed case from the status alone. This is a
-// safety net for unparseable bodies — well-formed responses still drive on
-// `code`.
+// KNOWN_ERROR_CODES maps the backend's exact error message strings (the only
+// thing it actually sends — no code field exists) to a stable client-side
+// code, so callers don't have to match on message text themselves. Backend
+// source: internal/api/handler.go, writeError call sites.
+const KNOWN_ERROR_CODES = {
+  'conversation is closed': 'conversation_closed',
+  'no pending clarification round': 'no_pending_clarification_round',
+  'clarification round already answered': 'clarification_round_already_answered',
+};
+
+// buildErrorForResponse reads the JSON body (if any) for a non-2xx response
+// and returns a typed ApiError. writeError always writes a body
+// ({"error": msg}, unconditionally, for every error path on the backend) —
+// there is no real empty-body case to guard against, so unlike a prior
+// version of this function, no status-based fallback is needed: an
+// unrecognised message simply gets `code: null`, and callers that only
+// handle specific codes correctly fall through to their generic path.
 async function buildErrorForResponse(response, genericMessage) {
-  let backendCode;
   let backendMessage;
   try {
     const body = await response.json();
-    if (body && typeof body === 'object') {
-      if (typeof body.code === 'string') backendCode = body.code;
-      if (typeof body.error === 'string') backendMessage = body.error;
+    if (body && typeof body === 'object' && typeof body.error === 'string') {
+      backendMessage = body.error;
     }
   } catch {
     // body was not JSON or unreadable — fall back to generic message
   }
+  const message = backendMessage ?? genericMessage;
   return new ApiError({
-    code: backendCode ?? (response.status === 409 ? 'ErrConversationClosed' : null),
+    code: KNOWN_ERROR_CODES[message] ?? null,
     status: response.status,
-    message: backendMessage ?? genericMessage,
+    message,
   });
 }
 

--- a/src/api.js
+++ b/src/api.js
@@ -53,11 +53,15 @@ export class ApiError extends Error {
 // thing it actually sends — no code field exists) to a stable client-side
 // code, so callers don't have to match on message text themselves. Backend
 // source: internal/api/handler.go, writeError call sites.
-const KNOWN_ERROR_CODES = {
-  'conversation is closed': 'conversation_closed',
-  'no pending clarification round': 'no_pending_clarification_round',
-  'clarification round already answered': 'clarification_round_already_answered',
-};
+// A Map (not a plain object) — the lookup key comes from the backend
+// response body, and a plain object's inherited properties (`__proto__`,
+// `constructor`, etc.) would resolve to a truthy non-string value for those
+// keys instead of the intended "unrecognised" case.
+const KNOWN_ERROR_CODES = new Map([
+  ['conversation is closed', 'conversation_closed'],
+  ['no pending clarification round', 'no_pending_clarification_round'],
+  ['clarification round already answered', 'clarification_round_already_answered'],
+]);
 
 // buildErrorForResponse reads the JSON body (if any) for a non-2xx response
 // and returns a typed ApiError. writeError always writes a body
@@ -78,7 +82,7 @@ async function buildErrorForResponse(response, genericMessage) {
   }
   const message = backendMessage ?? genericMessage;
   return new ApiError({
-    code: KNOWN_ERROR_CODES[message] ?? null,
+    code: KNOWN_ERROR_CODES.get(message) ?? null,
     status: response.status,
     message,
   });

--- a/src/api.test.js
+++ b/src/api.test.js
@@ -133,8 +133,16 @@ describe('api.sendMessage', () => {
     await expect(api.sendMessage('abc', 'x')).rejects.toThrow(/Failed to send/);
   });
 
-  it('throws a typed ApiError on 409 with backend code', async () => {
-    const body = JSON.stringify({ code: 'ErrConversationClosed', error: 'conversation closed' });
+  // The backend distinguishes 409 causes by message string only — writeError
+  // always sends {"error": msg}, never a code field (verified against
+  // internal/api/handler.go). One test per real cause, plus the
+  // unrecognised-message fallback.
+  it.each([
+    ['conversation is closed', 'conversation_closed'],
+    ['no pending clarification round', 'no_pending_clarification_round'],
+    ['clarification round already answered', 'clarification_round_already_answered'],
+  ])('derives code %j -> %j from the backend message string on 409', async (message, code) => {
+    const body = JSON.stringify({ error: message });
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValueOnce(
@@ -145,23 +153,23 @@ describe('api.sendMessage', () => {
     const err = await api.sendMessage('abc', 'x').catch((e) => e);
     expect(err).toBeInstanceOf(ApiError);
     expect(err.status).toBe(409);
-    expect(err.code).toBe('ErrConversationClosed');
-    expect(err.message).toBe('conversation closed');
+    expect(err.code).toBe(code);
+    expect(err.message).toBe(message);
   });
 
-  it('synthesises ErrConversationClosed on 409 with no body', async () => {
-    // Backend sometimes returns an empty 409 (e.g. panic mid-render). The
-    // adapter must still mark this as conversation-closed so App.jsx can
-    // branch on the status.
+  it('leaves code null for a 409 with an unrecognised message', async () => {
+    const body = JSON.stringify({ error: 'some future 409 cause not yet known to the frontend' });
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValueOnce(new Response('', { status: 409 })),
+      vi.fn().mockResolvedValueOnce(
+        new Response(body, { status: 409, headers: { 'Content-Type': 'application/json' } }),
+      ),
     );
 
     const err = await api.sendMessage('abc', 'x').catch((e) => e);
     expect(err).toBeInstanceOf(ApiError);
     expect(err.status).toBe(409);
-    expect(err.code).toBe('ErrConversationClosed');
+    expect(err.code).toBeNull();
   });
 });
 
@@ -234,8 +242,8 @@ describe('api.sendMessageStream', () => {
     ).rejects.toThrow(/Failed to send/);
   });
 
-  it('throws a typed ApiError on 409 with backend code', async () => {
-    const body = JSON.stringify({ code: 'ErrConversationClosed', error: 'conversation closed' });
+  it('derives code from the backend message string on 409', async () => {
+    const body = JSON.stringify({ error: 'conversation is closed' });
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValueOnce(
@@ -248,8 +256,25 @@ describe('api.sendMessageStream', () => {
       .catch((e) => e);
     expect(err).toBeInstanceOf(ApiError);
     expect(err.status).toBe(409);
-    expect(err.code).toBe('ErrConversationClosed');
-    expect(err.message).toBe('conversation closed');
+    expect(err.code).toBe('conversation_closed');
+    expect(err.message).toBe('conversation is closed');
+  });
+
+  it('does not misclassify a round-conflict 409 as conversation-closed', async () => {
+    const body = JSON.stringify({ error: 'clarification round already answered' });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce(
+        new Response(body, { status: 409, headers: { 'Content-Type': 'application/json' } }),
+      ),
+    );
+
+    const err = await api
+      .sendMessageStream('abc', { answers: [{ id: 'q1', text: 'x' }] }, vi.fn())
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.code).toBe('clarification_round_already_answered');
+    expect(err.code).not.toBe('conversation_closed');
   });
 
   it('forwards the body verbatim (clarification answers shape)', async () => {

--- a/src/api.test.js
+++ b/src/api.test.js
@@ -171,6 +171,26 @@ describe('api.sendMessage', () => {
     expect(err.status).toBe(409);
     expect(err.code).toBeNull();
   });
+
+  // KNOWN_ERROR_CODES uses a Map, not a plain object, specifically so a
+  // backend-controlled message string matching an inherited Object property
+  // name can't resolve to a truthy non-string value instead of "unrecognised".
+  it.each(['__proto__', 'constructor', 'toString'])(
+    'leaves code null for the message string %j (prototype-property name)',
+    async (message) => {
+      const body = JSON.stringify({ error: message });
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValueOnce(
+          new Response(body, { status: 409, headers: { 'Content-Type': 'application/json' } }),
+        ),
+      );
+
+      const err = await api.sendMessage('abc', 'x').catch((e) => e);
+      expect(err).toBeInstanceOf(ApiError);
+      expect(err.code).toBeNull();
+    },
+  );
 });
 
 // ── sendMessageStream ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- \`buildErrorForResponse\`/\`isConversationClosedError\` checked \`error.code === 'ErrConversationClosed'\` — a field the backend **never sends** (verified exhaustively against \`handler.go\`: \`writeError\` only ever writes \`{"error": msg}\`, no code field anywhere).
- The prior "any 409 → conversation closed" fallback misclassified the two other real 409 causes (\`"no pending clarification round"\`, \`"clarification round already answered"\`) as conversation-closed, showing users the wrong message.
- Replaced with \`KNOWN_ERROR_CODES\`, a client-side lookup from the backend's exact message string to a stable code. Removed the status-based synthetic-code fallback too — \`writeError\` always writes a body, so the "empty 409" case it guarded against can't occur.
- \`isConversationClosedError\` now only matches \`code === 'conversation_closed'\`, not any 409.

**Security review caught a real (if not currently exploitable) hazard**: \`KNOWN_ERROR_CODES\` was a plain object literal indexed by a backend-controlled string — a message matching an inherited \`Object\` property name (\`__proto__\`, \`constructor\`, \`toString\`) would resolve to a truthy non-string value instead of \`undefined\`. Fixed by switching to a \`Map\` (no prototype-inherited keys). Added regression tests for all three property names.

**Filed a follow-up issue (gh#100)** for a separate pre-existing bug found while verifying: \`handleAnswerSubmit\`'s non-closed catch path has a comment claiming it "restores pendingClarification" but never actually does — out of scope for this PR.

Closes #95

## Test plan
- [x] \`npm run lint\` passes
- [x] \`npm test\` passes (122/122, up from 114/114)
- [ ] No console errors
- [ ] Manual smoke test: trigger a real "clarification round already answered" 409 against the backend (double-submit an answer), confirm it does NOT show "conversation has been closed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)