### PR TITLE
⚡ task(dx): fix /plan typo in tech-lead.md pipeline diagram

### DIFF
--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -146,7 +146,7 @@ Prevent and reject:
 You sit between planning and implementation:
 
 ```
-/plan skill → Tech Lead (YOU) → implementation (main thread / bug-fixer / code-simplifier) → /find-bugs → /ship
+/backlog skill → Tech Lead (YOU) → implementation (main thread / bug-fixer / code-simplifier) → /find-bugs → /ship
 ```
 
 Your coordination responsibilities:


### PR DESCRIPTION
## Summary
- \`tech-lead.md:149\`'s pipeline diagram referenced a \`/plan\` skill that doesn't exist in this repo — corrected to \`/backlog\`, the actual skill name.

Closes #74

## Test plan
- [x] \`npm run lint\` passes
- [x] \`npm test\` passes (122/122, unaffected — docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)