### PR TITLE
⚖️ chore(dx): install graphify, fix self-learn's soft-nudge staleness

### DIFF
--- a/.claude/dreaming/dreaming.sh
+++ b/.claude/dreaming/dreaming.sh
@@ -48,6 +48,16 @@ echo "[$(date -Iseconds)] vmm-rada-web-ui dreaming pass started" >> "$LOG"
 # Run from project root so relative paths in prompt work.
 cd "$PROJECT_DIR"
 
+# graphify staleness safety net — the git post-commit/post-checkout hooks
+# (installed via `graphify hook install`) should keep graphify-out/graph.json
+# current automatically, but this flags it here too in case a hook ever
+# silently fails to fire on some future clone/machine. check-update is
+# explicitly documented as cron-safe (no LLM cost, exits non-fatally).
+if command -v graphify >/dev/null 2>&1 && [[ -f "$PROJECT_DIR/graphify-out/graph.json" ]]; then
+  echo "[$(date -Iseconds)] graphify check-update:" >> "$LOG"
+  graphify check-update "$PROJECT_DIR" >> "$LOG" 2>&1 || true
+fi
+
 PROMPT="$(cat "$PROMPT_FILE")
 Today is $(date -I).
 Current branch: $(git rev-parse --abbrev-ref HEAD).

--- a/.claude/hooks/session-self-learn.sh
+++ b/.claude/hooks/session-self-learn.sh
@@ -1,0 +1,306 @@
+#!/bin/bash
+# Stop hook: scans the session transcript for a win/mistake worth logging per
+# .claude/skills/self-learn/SKILL.md's schema, and appends directly to
+# _patterns/wins.jsonl / mistakes.jsonl if the model finds one.
+#
+# Why this exists: the PostToolUse prompt-nudge ("consider /self-learn log")
+# alone did not produce any logged patterns — both pattern files sat at 0
+# bytes for weeks despite the nudge firing on every Edit/Write. A reminder
+# that isn't acted on is barely better than no reminder. This hook removes
+# the "remember to log it" step entirely: the Stop hook already fires
+# reliably every session (session-end.sh/session-index.sh both depend on it
+# and both stay current), so pattern logging rides the same guarantee.
+#
+# Runs independently of session-end.sh — reads its own excerpt from the
+# transcript rather than depending on session-end.sh's output, so it still
+# fires if session-end.sh exits early (e.g. /session-end already ran).
+#
+# Bar for logging is deliberately conservative (see PROMPT below) — most
+# sessions have nothing worth logging, and a hook that logs too eagerly
+# defeats the purpose of a curated pattern store.
+#
+# Output: appends one line to _patterns/wins.jsonl or _patterns/mistakes.jsonl
+# (both gitignored, per-project local learning log).
+
+set -uo pipefail
+
+# shellcheck source=_lib/hook-common.sh
+source "$(dirname "$0")/_lib/hook-common.sh"
+hook_setup_logging "session-self-learn.sh"
+
+INPUT=$(cat)
+echo "[$(date -Iseconds)] session-self-learn invoked" >> "$LOG_FILE"
+
+PROJECT_ROOT="$(dirname "$0")/../.."
+PATTERNS_DIR="$PROJECT_ROOT/_patterns"
+TODAY=$(date '+%Y-%m-%d')
+PROJECT_NAME="vmm-rada-web-ui"
+
+TRANSCRIPT=$(echo "$INPUT" | python3 -c \
+  "import json,sys; d=json.load(sys.stdin); print(d.get('transcript_path',''))" 2>/dev/null || echo "")
+
+if [[ -z "$TRANSCRIPT" || ! -f "$TRANSCRIPT" ]]; then
+  PROJECT_HASH=$(pwd | sed 's|/|-|g')
+  TRANSCRIPT=$(ls -t "$HOME/.claude/projects/$PROJECT_HASH"/*.jsonl 2>/dev/null | head -1 || echo "")
+fi
+
+if [[ -z "$TRANSCRIPT" || ! -f "$TRANSCRIPT" ]]; then
+  echo "[$(date -Iseconds)] session-self-learn: no transcript found, skipping" >> "$LOG_FILE"
+  exit 0
+fi
+
+# Same excerpt shape as session-end.sh (last 30 user/assistant exchanges,
+# 600 chars each) — independent read, not a dependency on that script.
+EXCERPT=$(python3 - "$TRANSCRIPT" <<'PYEOF'
+import json, sys
+
+messages = []
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+            msg = entry.get('message', {})
+            role = msg.get('role', '')
+            content = msg.get('content', '')
+            if role not in ('user', 'assistant'):
+                continue
+            text = ''
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get('type') == 'text':
+                        text += block.get('text', '')
+            elif isinstance(content, str):
+                text = content
+            text = text.strip()
+            if text:
+                messages.append(f"[{role}]: {text[:600]}")
+        except Exception:
+            pass
+
+print('\n\n'.join(messages[-30:]))
+PYEOF
+)
+
+if [[ -z "$EXCERPT" ]]; then
+  echo "[$(date -Iseconds)] session-self-learn: empty transcript, skipping" >> "$LOG_FILE"
+  exit 0
+fi
+
+PROMPT="Review this Claude Code session transcript. Decide if anything happened
+that matches one of these two patterns:
+
+MISTAKE — something went wrong that cost real rework (not a typo caught
+instantly), a banned pattern was used, or the agent guessed instead of
+verifying and it produced a wrong result.
+
+WIN — something worked well in a genuinely non-obvious way: a good judgment
+call, effective delegation/planning, or a design decision that was
+challenged and confirmed correct. Task success alone is NOT a win — most
+sessions succeed; that is not noteworthy.
+
+Bar for logging: be conservative. Most sessions have NOTHING worth logging.
+Only flag a pattern that would help a future session avoid the same mistake
+or repeat the same good judgment call.
+
+If nothing qualifies, respond with exactly: NONE
+
+If a MISTAKE qualifies, respond with ONLY this JSON (no prose, no markdown fences, no extra fields):
+{\"task\":\"<one sentence>\",\"mistake\":\"<one sentence>\",\"resolution\":\"<one sentence>\",\"pattern\":\"<one sentence, generalizable>\",\"severity\":\"low|medium|high\",\"category\":\"wrong_assumption|missed_context|didnt_ask|skipped_planning|tooling_error|context_waste|api_error|banned_pattern|other\",\"had_verification\":true|false,\"session_hygiene\":\"kitchen_sink|correction_spiral|context_overload|null\"}
+
+If a WIN qualifies, respond with ONLY this JSON (no prose, no markdown fences, no extra fields):
+{\"task\":\"<one sentence>\",\"win\":\"<one sentence>\",\"pattern\":\"<one sentence, reusable>\",\"reusable_in\":\"<one sentence>\",\"had_verification\":true|false,\"used_plan_mode\":true|false,\"delegation\":\"subagent|manual|none\",\"decomposed\":true|false}
+
+Before writing any field, strip API keys, tokens, credentials, or personal
+data — summarize the lesson, never quote a secret.
+
+SESSION TRANSCRIPT:
+$EXCERPT"
+
+# is_none_response / is_json_response distinguish the three valid outcomes
+# from a model that ignored instructions and returned chit-chat — mirrors
+# session-end.sh's is_valid_summary guard, adapted for this hook's ternary
+# output (NONE | mistake-JSON | win-JSON) instead of a single summary shape.
+is_none_response() {
+  [[ "$(echo "$1" | tr -d '[:space:]')" == "NONE" ]]
+}
+
+is_json_response() {
+  [[ "$1" == \{* ]] && [[ "$1" == *\} ]]
+}
+
+try_agy() {
+  local models=(
+    "Gemini 3.5 Flash (Low)"
+    "Gemini 3.5 Flash (Medium)"
+    "Gemini 3.1 Pro (Low)"
+  )
+  command -v agy &>/dev/null || return 1
+  for model in "${models[@]}"; do
+    echo "[$(date -Iseconds)] session-self-learn: trying agy model: $model" >> "$LOG_FILE"
+    local result
+    result=$(timeout 45 agy -p "$1" --model "$model" 2>>"$LOG_FILE") && \
+      { is_none_response "$result" || is_json_response "$result"; } && { echo "$result"; return 0; }
+    echo "[$(date -Iseconds)] session-self-learn: agy model $model returned unusable output" >> "$LOG_FILE"
+  done
+  return 1
+}
+
+PROMPT_TMP=$(mktemp /tmp/session-self-learn-prompt.XXXXXX)
+echo "$PROMPT" > "$PROMPT_TMP"
+trap 'rm -f "$PROMPT_TMP"' EXIT
+
+try_opencode() {
+  local models=(
+    "ollama/glm-5.2:cloud"
+    "ollama/qwen3.5:cloud"
+  )
+  command -v opencode &>/dev/null || return 1
+  for model in "${models[@]}"; do
+    echo "[$(date -Iseconds)] session-self-learn: trying opencode model: $model" >> "$LOG_FILE"
+    local result
+    result=$(timeout 45 opencode run "Follow the instructions in the attached file exactly." \
+      --file "$PROMPT_TMP" --model "$model" --format json 2>>"$LOG_FILE" | \
+      python3 -c "
+import json,sys
+parts=[]
+for line in sys.stdin:
+    line=line.strip()
+    if not line: continue
+    try:
+        obj=json.loads(line)
+        if obj.get('type')=='text':
+            parts.append(obj['part']['text'])
+    except: pass
+print(''.join(parts).strip())
+") && { is_none_response "$result" || is_json_response "$result"; } && { echo "$result"; return 0; }
+    echo "[$(date -Iseconds)] session-self-learn: opencode model $model returned unusable output" >> "$LOG_FILE"
+  done
+  return 1
+}
+
+RESULT=""
+RESULT=$(try_agy "$PROMPT" 2>>"$LOG_FILE") || true
+
+if [[ -z "$RESULT" ]]; then
+  RESULT=$(try_opencode 2>>"$LOG_FILE") || true
+fi
+
+if [[ -z "$RESULT" ]]; then
+  echo "[$(date -Iseconds)] session-self-learn: all LLMs failed, skipping this session" >> "$LOG_FILE"
+  exit 0
+fi
+
+if is_none_response "$RESULT"; then
+  echo "[$(date -Iseconds)] session-self-learn: NONE — nothing worth logging" >> "$LOG_FILE"
+  exit 0
+fi
+
+# Validate strictly and inject date/project deterministically (never trust
+# the model for these two fields — it has no reliable way to know "today"
+# and no reason to ever return a different project name than this hook's
+# own PROJECT_NAME). Malformed JSON or a field outside its enum is logged
+# and dropped, never appended — a corrupted jsonl line is worse than a
+# missed log entry.
+mkdir -p "$PATTERNS_DIR"
+python3 - "$RESULT" "$TODAY" "$PROJECT_NAME" "$PATTERNS_DIR" <<'PYEOF' >> "$LOG_FILE" 2>&1
+import json, sys
+
+raw, today, project, patterns_dir = sys.argv[1:5]
+
+try:
+    obj = json.loads(raw)
+except Exception as e:
+    print(f"session-self-learn: model output was not valid JSON: {e}")
+    sys.exit(0)
+
+MISTAKE_SEVERITY = {"low", "medium", "high"}
+MISTAKE_CATEGORY = {
+    "wrong_assumption", "missed_context", "didnt_ask", "skipped_planning",
+    "tooling_error", "context_waste", "api_error", "banned_pattern", "other",
+}
+MISTAKE_HYGIENE = {"kitchen_sink", "correction_spiral", "context_overload", "null", None}
+DELEGATION = {"subagent", "manual", "none"}
+
+def is_bool(v):
+    return isinstance(v, bool)
+
+def is_nonempty_str(v):
+    return isinstance(v, str) and v.strip() != ""
+
+if "mistake" in obj:
+    required_str = ["task", "mistake", "resolution", "pattern"]
+    if not all(is_nonempty_str(obj.get(k)) for k in required_str):
+        print("session-self-learn: mistake JSON missing required string field(s)")
+        sys.exit(0)
+    if obj.get("severity") not in MISTAKE_SEVERITY:
+        print(f"session-self-learn: mistake JSON invalid severity: {obj.get('severity')!r}")
+        sys.exit(0)
+    if obj.get("category") not in MISTAKE_CATEGORY:
+        print(f"session-self-learn: mistake JSON invalid category: {obj.get('category')!r}")
+        sys.exit(0)
+    if not is_bool(obj.get("had_verification")):
+        print("session-self-learn: mistake JSON had_verification not a bool")
+        sys.exit(0)
+    hygiene = obj.get("session_hygiene")
+    if hygiene not in MISTAKE_HYGIENE:
+        print(f"session-self-learn: mistake JSON invalid session_hygiene: {hygiene!r}")
+        sys.exit(0)
+    entry = {
+        "date": today,
+        "project": project,
+        "task": obj["task"],
+        "mistake": obj["mistake"],
+        "resolution": obj["resolution"],
+        "pattern": obj["pattern"],
+        "severity": obj["severity"],
+        "category": obj["category"],
+        "had_verification": obj["had_verification"],
+        "session_hygiene": None if hygiene in ("null", None) else hygiene,
+    }
+    target = f"{patterns_dir}/mistakes.jsonl"
+    with open(target, "a") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    print(f"session-self-learn: appended mistake ({entry['category']}, {entry['severity']}) to {target}")
+
+elif "win" in obj:
+    required_str = ["task", "win", "pattern", "reusable_in"]
+    if not all(is_nonempty_str(obj.get(k)) for k in required_str):
+        print("session-self-learn: win JSON missing required string field(s)")
+        sys.exit(0)
+    if not is_bool(obj.get("had_verification")):
+        print("session-self-learn: win JSON had_verification not a bool")
+        sys.exit(0)
+    if not is_bool(obj.get("used_plan_mode")):
+        print("session-self-learn: win JSON used_plan_mode not a bool")
+        sys.exit(0)
+    if obj.get("delegation") not in DELEGATION:
+        print(f"session-self-learn: win JSON invalid delegation: {obj.get('delegation')!r}")
+        sys.exit(0)
+    if not is_bool(obj.get("decomposed")):
+        print("session-self-learn: win JSON decomposed not a bool")
+        sys.exit(0)
+    entry = {
+        "date": today,
+        "project": project,
+        "task": obj["task"],
+        "win": obj["win"],
+        "pattern": obj["pattern"],
+        "reusable_in": obj["reusable_in"],
+        "had_verification": obj["had_verification"],
+        "used_plan_mode": obj["used_plan_mode"],
+        "delegation": obj["delegation"],
+        "decomposed": obj["decomposed"],
+    }
+    target = f"{patterns_dir}/wins.jsonl"
+    with open(target, "a") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    print(f"session-self-learn: appended win to {target}")
+
+else:
+    print("session-self-learn: JSON had neither 'mistake' nor 'win' key, dropping")
+PYEOF
+
+echo "[$(date -Iseconds)] session-self-learn: done" >> "$LOG_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,6 +50,26 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/val/.local/bin/graphify hook-guard search"
+          }
+        ]
+      },
+      {
+        "matcher": "Read|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/val/.local/bin/graphify hook-guard read"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/val/.local/bin/graphify hook-guard search"
+            "command": "command -v graphify >/dev/null 2>&1 && graphify hook-guard search || true"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/val/.local/bin/graphify hook-guard read"
+            "command": "command -v graphify >/dev/null 2>&1 && graphify hook-guard read || true"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ dist-ssr
 # /self-learn pattern data — local learning log, not source
 _patterns/*.jsonl
 
+# graphify generated artifacts — rebuilt via git hooks, not source
+graphify-out/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,3 +142,13 @@ applied via `/apply-dreaming`.
   `council_type: "default"`. All seven strategies are already supported by
   the Stage 2 dispatcher and the message state shape — only the
   request-composition and any strategy-selection UI are missing.
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).


### PR DESCRIPTION
## Summary

Per \`~/wrk/common/tmp/vmm-rada-graphify-selflearn-setup.md\`. This project had no code-graph tooling and self-learn's pattern files sat at 0 bytes since 2026-07-20 despite the \`PostToolUse\` reminder hook already firing on every Edit/Write.

**graphify:**
- \`graphify claude install\` — \`CLAUDE.md\` graphify section + \`PreToolUse\` hooks (Bash search-guard, Read\|Glob read-guard) in \`.claude/settings.json\`
- \`graphify hook install\` — native git post-commit/post-checkout hooks to keep \`graphify-out/graph.json\` current automatically
- Initial build (\`graphify extract . --backend ollama --model qwen3.5:cloud\` — \`GEMINI_API_KEY\` in env was invalid, ollama cloud backend worked) + \`cluster-only\`: 258 nodes, 267 edges, 64 communities, 76K in / 16K out tokens. Smoke-tested with a query.
- \`.gitignore\`: \`graphify-out/\`
- \`.claude/dreaming/dreaming.sh\`: added a \`graphify check-update\` safety-net step

**self-learn:**
- New \`.claude/hooks/session-self-learn.sh\`, registered as a third \`Stop\` hook alongside \`session-end.sh\`/\`session-index.sh\` (both already proven reliable). Reuses the same transcript-excerpt + agy/opencode fallback chain as \`session-end.sh\`, asks a cheap model whether anything matches self-learn's win/mistake schema (conservative bar), appends directly to \`_patterns/*.jsonl\` if so. Strict server-side validation before any write — malformed output is dropped, never appended. Tested end-to-end with two synthetic transcripts (clear mistake, trivial nothing-to-log) — both correct.

## Security review findings

- **Fixed**: hardcoded \`/home/val/.local/bin/graphify\` path in \`.claude/settings.json\` — now resolved via \`PATH\` with a \`command -v\` guard (second commit).
- **Accepted trade-off, not fixed** (both are the graphify tool's and this project's existing designed behavior, not new exposure introduced here):
  - graphify's \`PreToolUse\` hooks inject "MANDATORY" directive-shaped text as \`additionalContext\` — intentional per graphify's own design (confirmed working the same way in the sibling lance-agent project). Verified directly that this is advisory text Claude retains discretion over, not an instruction-execution vector.
  - \`session-self-learn.sh\` sends a transcript excerpt to cloud LLMs (Gemini/Ollama) — same risk profile as the already-shipped \`session-end.sh\`, which does the same thing; secret-stripping is a prompt instruction, not enforced pre-send.

## Test plan
- [x] \`npm run lint\` passes
- [x] \`npm test\` passes (122/122, unaffected — no \`src/\` change)
- [x] \`graphify hook status\` confirms both git hooks installed
- [x] \`session-self-learn.sh\` tested end-to-end with two synthetic transcripts
- [ ] Observe over a few real sessions that \`_patterns/*.jsonl\` actually accumulates entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)