### PR TITLE
⚡ task(dx): wire /doubt-driven-development into the workflow gate

### DIFF
--- a/.claude/context-essentials.md
+++ b/.claude/context-essentials.md
@@ -41,6 +41,12 @@ contract and require Tech Lead override.
 - **`/fix-review`** runs parallel multi-model review (Ollama, see `config.yaml`)
   + Claude arbiter. **Not** Copilot-based — Copilot was dropped from the org
   workflow 2026-05-13; never wait for it.
+- **`/doubt-driven-development`** is the in-flight adversarial review gate for
+  non-trivial decisions (architectural choices, irreversible ops, security-
+  sensitive logic, unfamiliar code) **before they stand** — complementary to
+  `/fix-review` (post-hoc verdict on a finished artifact). Apply on
+  `/backlog` plans whose risks/blast-radius match the skill's "non-trivial"
+  list, not on mechanical edits.
 
 ## Docs discipline
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -106,6 +106,8 @@ Logs mistakes/wins to `_patterns/*.jsonl`; auto-promotes recurring patterns to h
 
 Spawns a fresh-context reviewer biased to disprove, not approve. Complements `/fix-review`, which is a post-hoc verdict.
 
+**Wired into the workflow gate** (between `tech-lead` approval and `code-generator` in the Feature implementation pipeline below) so non-trivial decisions are reviewed *before* code generation, while course-correction is still cheap — not just after the fact as `/fix-review` does. Skip only for mechanical edits where the risk/blast-radius doesn't match the skill's "non-trivial" criteria.
+
 ### `/session-end` — Write session summary
 
 **When to use:** manually, or let it auto-run on session Stop.
@@ -207,6 +209,8 @@ Human or /backlog
     ↓ plan + issue
 tech-lead (if architecture-sensitive)
     ↓ approval
+/doubt-driven-development (if non-trivial)     ← in-flight adversarial review,
+    ↓                                            course-correct while cheap
 code-generator
     ↓ implementation + lint
 ┌──────────────────────────────┐  ← parallel


### PR DESCRIPTION
## Summary
- \`.claude/context-essentials.md\` §Workflow gates: new bullet explicitly naming \`/doubt-driven-development\` as the in-flight adversarial review gate (complementary to \`/fix-review\`'s post-hoc verdict), with when-to-apply criteria mirrored from the skill's own "non-trivial" definition.
- \`docs/development-workflow.md\`: matching usage note on the skill's own entry, plus an inserted step in the Feature implementation pipeline diagram between \`tech-lead\` approval and \`code-generator\`.

Wires an already-installed, already-documented skill into the documented pipeline flow — the skill was listed in \`CLAUDE.md\`, but \`grep\` across \`ship/SKILL.md\`, \`backlog/SKILL.md\`, \`context-essentials.md\`, and \`development-workflow.md\` returned zero workflow-gate hits. Its entire value is in-flight adversarial review of non-trivial decisions; without this wiring, it was just documentation.

Closes #72

## Test plan
- [x] \`npm run lint\` passes
- [x] \`npm test\` passes (122/122, unaffected — docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)