### PR TITLE
⚡ fix(app): restore pendingClarification on non-closed answer failures

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -357,6 +357,20 @@ function App() {
 
     setIsLoading(true);
 
+    // Capture the current pendingClarification before the optimistic clear
+    // below, so a non-closed failure catch path can restore it — without this,
+    // a network blip or round-conflict 409 during answer submission would
+    // silently disappear the clarification UI with no error and no way to
+    // retry (the prior code claimed to restore it but never actually did,
+    // see gh#100).
+    let submittedClarification = null;
+    {
+      const last = currentConversation?.messages?.at(-1);
+      if (last?.role === 'assistant') {
+        submittedClarification = last.pendingClarification ?? null;
+      }
+    }
+
     const updateLast = (updater) =>
       setCurrentConversation((prev) => {
         const messages = [...prev.messages];
@@ -394,15 +408,20 @@ function App() {
           return { ...prev, messages, closed: true };
         });
       } else {
-        // Any other failure: restore the pendingClarification so the user can
-        // retry. The optimistic clearing we did above is reverted.
+        // Any other failure: actually restore the captured pendingClarification
+        // so the user can retry through the same UI (Stage 0's question text +
+        // answer textareas render again). The optimistic clearing we did above
+        // is reverted, AND the user's typed answers are preserved in the
+        // answer textareas (since they're already in the DOM, controlled by
+        // Stage0's internal draftAnswers state — the captured
+        // pendingClarification just makes Stage0 render again).
         setCurrentConversation((prev) => {
           if (!prev) return prev;
           const messages = [...prev.messages];
           const last = messages[messages.length - 1];
           if (last && last.role === 'assistant') {
-            last.error = null;
-            last.loading = { ...last.loading, stage1: false };
+            last.pendingClarification = submittedClarification;
+            last.loading = { ...last.loading, stage0: false, stage1: false, stage2: false, stage3: false };
           }
           return { ...prev, messages };
         });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -455,6 +455,71 @@ describe('409 handling on handleAnswerSubmit', () => {
       expect(screen.queryByText(/This conversation has been closed/i)).not.toBeInTheDocument();
     });
   });
+
+  it('restores pendingClarification on a non-closed 409 (gh#100 regression)', async () => {
+    // Prior to this fix, the non-closed catch branch's comment claimed to
+    // restore pendingClarification but the code never actually set it
+    // back — a network blip, a round-conflict 409 (other than
+    // conversation_closed), or any other error during answer submission
+    // would silently disappear the Stage 0 UI with no error and no way
+    // to retry. Now: pendingClarification is restored, Stage 0 renders
+    // again (question text + answer textareas).
+    mockApi.listConversations.mockResolvedValue([
+      { id: 'conv-1', title: 'One', created_at: '2026-05-02T12:00:00Z' },
+    ]);
+    mockApi.getConversation.mockResolvedValue(makeConversation());
+    mockApi.sendMessageStream
+      .mockImplementationOnce(
+        scriptedStream([
+          [
+            'stage0_round_complete',
+            { type: 'stage0_round_complete', data: { round: 1, questions: [{ id: 'q1', text: 'Which framework?' }] } },
+          ],
+        ]),
+      )
+      .mockRejectedValueOnce(
+        new ApiError({
+          code: 'clarification_round_already_answered',
+          status: 409,
+          message: 'clarification round already answered',
+        }),
+      );
+
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: /One/ }));
+
+    const input = await screen.findByPlaceholderText(/Ask a question/i);
+    await waitFor(() => expect(input).not.toBeDisabled());
+
+    await user.type(input, 'help me choose');
+    await user.click(screen.getByRole('button', { name: /Send/i }));
+
+    // Stage 0 renders the answer textarea + Submit/Skip buttons.
+    const answerTextarea = await screen.findByPlaceholderText(/Your answer/i);
+    await user.type(answerTextarea, 'react');
+    await user.click(screen.getByRole('button', { name: /Submit answers/i }));
+
+    // The bug: prior to the fix, the round-conflict 409 would clear
+    // pendingClarification optimistically, then fail to restore it —
+    // Stage 0's answer textarea would silently disappear (the
+    // `findByPlaceholderText` from earlier would never re-resolve, OR
+    // if the test waited, it would simply not be there). The fix:
+    // pendingClarification is captured before the optimistic clear, then
+    // restored in this catch branch — Stage 0 renders again with the
+    // captured question text. (The Ask-a-question input stays disabled
+    // by design while a clarification is pending — ChatInterface renders
+    // the answer-style placeholder to redirect the user to the
+    // clarification form. That is correct behavior, not a regression.)
+    expect(await screen.findByPlaceholderText(/Your answer/i)).toBeInTheDocument();
+    // The question text is restored too (not just the textarea surface).
+    expect(await screen.findByText(/Which framework\?/i)).toBeInTheDocument();
+    // The submit/skip buttons come back.
+    expect(screen.getByRole('button', { name: /Submit answers/i })).toBeInTheDocument();
+    // The conversation is NOT marked closed (this is a non-closed 409).
+    expect(screen.queryByText(/This conversation has been closed/i)).not.toBeInTheDocument();
+  });
 });
 
 // ── Stage 2/3 loading spinners (gh#96) ──────────────────────────────────────


### PR DESCRIPTION
## Summary
- \`src/App.jsx\` \`handleAnswerSubmit\`: captures \`pendingClarification\` before the optimistic clear, then actually restores it in the non-conversation-closed catch branch (previously the code's comment said "restore" but never set \`last.pendingClarification\` back to a truthy value). Resets all loading flags so Stage 0 fully re-renders.
- \`src/App.test.jsx\`: regression test covering the realistic path — a \`clarification_round_already_answered\` 409 during answer submit. Asserts the answer textarea, question text, and Submit button all come back, and that the conversation is NOT marked closed.

Closes #100

## Test plan
- [x] \`npm run lint\` passes
- [x] \`npm test\` passes (123/123, up from 122/122)

🤖 Generated with [Claude Code](https://claude.com/claude-code)