### PR TITLE
⚡ chore(config): add engine-strict to .npmrc so engines is actually enforced

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
## Summary
- New \`.npmrc\` with \`engine-strict=true\` — \`engines.node >=22\` in \`package.json\` is now actually enforced by npm, not just advisory.
- Verified locally: \`npm install\` still succeeds cleanly on Node 22.23.1, \`npm config get engine-strict\` reports \`true\`.

Closes #86

## Test plan
- [x] \`npm run lint\` passes
- [x] \`npm test\` passes (123/123, unaffected — no source change)
- [ ] CI green (CI runs Node 22 already, so no-op expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)