### PR TITLE
⚡ docs: reconcile branch prefix lists (CLAUDE.md vs development-workflow.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,15 +83,9 @@ Backend config env vars relevant to frontend: `RADA_MODELS` (default-strategy mo
 
 ## Workflow
 
-**Branch naming:**
-```
-feat/{short-description}      e.g. feat/stage3-error-ui
-fix/{description}             e.g. fix/loading-stage3-never-clears
-docs/{description}            e.g. docs/update-streaming-contract
-refactor/{description}        e.g. refactor/extract-sse-handler
-```
-
-**Commit format:** `fix(scope): description` / `feat(scope): description` / `docs: description`
+**Branch naming and commit format:** see `docs/development-workflow.md` §
+"Branch, Commit, and PR Conventions" — the single source of truth for both
+lists (includes `chore/` and `task(scope):`, which this file used to omit).
 
 **Debt levels** — label all PRs and proposals:
 - ⚡ quick-fix: targeted, no refactor


### PR DESCRIPTION
## Summary
- `CLAUDE.md` §Workflow duplicated a stale branch-naming/commit-format list (missing `chore/` and `task(scope):`, even though 4 of the last 8 branches used `chore/`).
- `docs/development-workflow.md` already had the complete, correct list.
- Replaced the duplicate in `CLAUDE.md` with a pointer to the single source of truth, so the two docs can't drift again.

Closes #79

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (123/123)
- [x] Docs-only change — no dev server / runtime verification needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)