### PR TITLE
⚖️ feat(fix-review): add external_agents as a genuine tier 2 in the failover cascade

### DIFF
--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -290,6 +290,13 @@ dispatch_round() {
         cat "$PROMPT_FILE" | bash .claude/skills/fix-review/ollama-review.sh "$cli_model"
       fi
       ;;
+    *)
+      # $TIER should only ever be "cloud" or "external_agents" (set in Step 2)
+      # — an unset/typo'd value must not silently degrade to "0 findings" and
+      # look like a clean review. Fail loudly instead.
+      echo "error: dispatch_round: unrecognized \$TIER='$TIER' — check Step 2's probe logic" >&2
+      exit 1
+      ;;
   esac
 }
 ```
@@ -309,6 +316,14 @@ R1=$(dispatch_round 1 "$ROUND1" "$CLI1")
 ```
 Skip R2/R3 entirely — do not call them, and treat their findings as absent
 (not as empty-array votes) when tallying.
+
+Once every round needed has been dispatched, clean up — the prompt file
+contains the PR diff, and `$RUN_DIR` may contain external-agent output,
+neither of which should linger in `/tmp`:
+```bash
+rm -f "$PROMPT_FILE"
+rm -rf "$RUN_DIR"
+```
 
 Each call returns a JSON array (empty `[]` on parse failure — safe degradation).
 The JSON output contract (raw array, `file/line/layer/severity/description`)

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -261,7 +261,11 @@ $(cat baseline.diff)"
 
 Send the prompt to each reviewer model, routed through whichever tier is
 active (`$TIER` from Step 2). The external-agent adapters read their prompt
-from a file, not a shell variable, so write it once:
+from a file, not a shell variable, so write it once. `lib/agents.sh` requires
+`yq` and `jq` on `PATH` (used to parse `reviewers.external_agents` from
+config.yaml and each tool's JSON output envelope) — both are personal-machine
+prerequisites for this skill already, same category as `ollama serve` and
+the external-agent CLIs themselves, not something CI needs:
 
 ```bash
 PROMPT_FILE=$(mktemp)

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -4,7 +4,7 @@ description: Multi-model PR review pipeline. Dispatches the diff concurrently to
 user-invocable: true
 argument-hint: "[pr-number]"
 metadata:
-  version: "2.2.0"
+  version: "2.3.0"
   domain: code-review
   scope: quality-gate
   debt-level: balanced
@@ -70,8 +70,14 @@ Note: `config.yaml` uses `round_1/round_2/round_3` keys for historical reasons �
 are concurrent dispatches, not sequential rounds. The models to use are always read from
 `config.yaml`; do not hardcode model names here.
 
-CLI failover tier (config.yaml `reviewers.cli`) engages automatically when the Ollama
-cloud endpoint probe fails — same flow, local models instead of cloud.
+Three tiers, tried in order per round when the one above it is unavailable:
+1. **Cloud** (`reviewers.openrouter`) — the default path.
+2. **External agents** (`reviewers.external_agents`) — free-tier CLI tools
+   (cursor-agent, omp, codex, opencode, kilo; see `.claude/skills/lib/agents.sh`),
+   engages when the Ollama cloud endpoint is unreachable or has none of the
+   configured models loaded.
+3. **CLI** (`reviewers.cli`, actually local Ollama despite the key name) —
+   last resort, engages only if every external agent above also failed.
 
 ## Step-by-step execution
 
@@ -161,7 +167,9 @@ comment reports.
 Read `.claude/skills/fix-review/config.yaml`. Extract:
 - `reviewers.openrouter.round_1/2/3` — cloud reviewer models
 - `openrouter_api_url` — Ollama endpoint (`http://localhost:11434/v1/chat/completions`)
-- `reviewers.cli` — local failover models (used if cloud endpoint unreachable)
+- `reviewers.external_agents` — ordered list of free-tier CLI tools, tier 2
+- `reviewers.cli` — local failover models, tier 3 (used if cloud AND every
+  external agent failed)
 
 First, extract the actual model names you just read from `config.yaml`:
 ```bash
@@ -176,8 +184,8 @@ Then probe the endpoint:
 MODELS_JSON=$(curl -sf --max-time 5 http://localhost:11434/v1/models 2>/dev/null)
 
 if [ -z "$MODELS_JSON" ]; then
-  TIER="cli"
-  echo "⚠️  Ollama endpoint unreachable — using CLI tier"
+  TIER="external_agents"
+  echo "⚠️  Ollama endpoint unreachable — trying external_agents tier"
 else
   # Extract model IDs robustly (handles spaces after colon in JSON)
   AVAILABLE=$(echo "$MODELS_JSON" | grep -oP '"id"\s*:\s*"\K[^"]+')
@@ -186,14 +194,19 @@ else
      || echo "$AVAILABLE" | grep -qF "$ROUND3"; then
     TIER="cloud"
   else
-    TIER="cli"
-    echo "⚠️  Ollama online but none of the configured models loaded — using CLI tier"
+    TIER="external_agents"
+    echo "⚠️  Ollama online but none of the configured models loaded — trying external_agents tier"
     echo "    Expected one of: $ROUND1 | $ROUND2 | $ROUND3"
   fi
 fi
 ```
 
-If `TIER="cli"` for any reason → use CLI failover tier (`reviewers.cli`).
+If `TIER="cloud"`, Step 3 dispatches via `ollama-review.sh` as before. Otherwise
+(`TIER="external_agents"`), Step 3 tries each dispatched round against
+`reviewers.external_agents` (`.claude/skills/lib/agents.sh`) first; a round
+falls through to `reviewers.cli` (tier 3, real local Ollama despite the `cli`
+key name) only if every external agent for that round also failed/returned
+empty.
 
 ### 3. Concurrent review dispatch
 
@@ -246,19 +259,53 @@ ${INSTRUCTIONS}
 $(cat baseline.diff)"
 ```
 
-Send the prompt to each reviewer model via `ollama-review.sh`. The number of
-models called depends on `REVIEWER_COUNT` from Step 1.5:
+Send the prompt to each reviewer model, routed through whichever tier is
+active (`$TIER` from Step 2). The external-agent adapters read their prompt
+from a file, not a shell variable, so write it once:
+
+```bash
+PROMPT_FILE=$(mktemp)
+printf '%s' "$PROMPT" > "$PROMPT_FILE"
+
+source .claude/skills/lib/agents.sh
+RUN_DIR=$(mktemp -d)
+
+# CLI2/CLI3 not needed if REVIEWER_COUNT=1. reviewers.cli has no round_N
+# keys (unlike reviewers.openrouter) — map positionally, list order = round order.
+CLI1="<exact reviewers.cli[0] model>"   # e.g. qwen3-coder:30b
+CLI2="<exact reviewers.cli[1] model>"   # e.g. qwen2.5-coder:7b
+CLI3="<exact reviewers.cli[2] model>"   # e.g. granite3.3:8b
+
+dispatch_round() {
+  local n="$1" cloud_model="$2" cli_model="$3"
+  case "$TIER" in
+    cloud)
+      cat "$PROMPT_FILE" | bash .claude/skills/fix-review/ollama-review.sh "$cloud_model"
+      ;;
+    external_agents)
+      if try_external_agents "$n" "$PROMPT_FILE" .claude/skills/fix-review/config.yaml "$RUN_DIR"; then
+        cat "$RUN_DIR/round_${n}.raw.json"
+      else
+        echo "warn: round $n — all external_agents failed, falling back to local Ollama (cli tier)" >&2
+        cat "$PROMPT_FILE" | bash .claude/skills/fix-review/ollama-review.sh "$cli_model"
+      fi
+      ;;
+  esac
+}
+```
+
+The number of rounds called depends on `REVIEWER_COUNT` from Step 1.5:
 
 **`REVIEWER_COUNT=3`** (diff touches a security-relevant surface — default, unchanged behavior):
 ```bash
-R1=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_1_model>)
-R2=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_2_model>)
-R3=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_3_model>)
+R1=$(dispatch_round 1 "$ROUND1" "$CLI1")
+R2=$(dispatch_round 2 "$ROUND2" "$CLI2")
+R3=$(dispatch_round 3 "$ROUND3" "$CLI3")
 ```
 
 **`REVIEWER_COUNT=1`** (no security-relevant surface touched):
 ```bash
-R1=$(echo "$PROMPT" | bash .claude/skills/fix-review/ollama-review.sh <round_1_model>)
+R1=$(dispatch_round 1 "$ROUND1" "$CLI1")
 ```
 Skip R2/R3 entirely — do not call them, and treat their findings as absent
 (not as empty-array votes) when tallying.
@@ -266,6 +313,10 @@ Skip R2/R3 entirely — do not call them, and treat their findings as absent
 Each call returns a JSON array (empty `[]` on parse failure — safe degradation).
 The JSON output contract (raw array, `file/line/layer/severity/description`)
 is preserved — the project-facts block changes input context, not parse contract.
+Record which tier actually produced each round's result (cloud model name,
+external-agent tool name from `$RUN_DIR/round_${n}.failover`, or cli model
+name) — Step 6's PR comment reports this per round, not just the configured
+cloud model.
 
 ### 4. Tally findings
 
@@ -319,9 +370,14 @@ gh issue create --title "..." --body "..."
 
 ### 6. Post PR comment
 
-Post a single collapsible summary. The `Models:` line lists only the models
+Post a single collapsible summary. The `Models:` line lists only the rounds
 actually dispatched (per `REVIEWER_COUNT` from Step 1.5) — never claim three
-reviewers ran when only `round_1` was called:
+reviewers ran when only `round_1` was called — and names **what actually
+produced each round's result**, not just the configured cloud model: if
+`$TIER=cloud`, that's the cloud model; if a round fell through to
+`external_agents`, name the tool that succeeded (from
+`$RUN_DIR/round_${n}.failover`); if it fell all the way to `cli`, name the
+local model:
 
 ```
 <details>
@@ -332,15 +388,17 @@ reviewers ran when only `round_1` was called:
 | src/components/Stage2.jsx:42 | 2/3 | 2 | error | CONFIRM | missing null check on metadata.label_to_model |
 | src/api.js:87 | 1/3 | 5 | sugg | DISMISS | style — not flagged by pyramid |
 
-Models: <round_1_model>, <round_2_model>, <round_3_model> (from config.yaml)
+Models: round_1=<round_1_model>, round_2=<round_2_model>, round_3=<round_3_model> (from config.yaml)
 Arbiter: Claude Sonnet 4.6
 
 </details>
 ```
 
 For a `REVIEWER_COUNT=1` pass (no security-relevant surface touched), the
-`Models:` line lists only `<round_1_model>`, and vote counts read `N/1`
-instead of `N/3`.
+`Models:` line lists only round 1, and vote counts read `N/1` instead of
+`N/3`. Example of a mixed-tier pass: `Models: round_1=cursor-agent (auto)
+[external_agents], round_2=minimax-m2.7:cloud [cloud], round_3=granite3.3:8b
+[cli]`.
 
 ### 7. Merge decision
 

--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -15,8 +15,23 @@ reviewers:
     round_2: { model: minimax-m2.7:cloud }          # MiniMax, non-thinking, long-ctx
     round_3: { model: gemma4:31b-cloud }            # Gemma code model, non-thinking
 
-  # Local failover tier — tools-capable models, no network dependency.
-  # Engages automatically when the Ollama cloud endpoint probe fails.
+  # Tier 2 — external agent CLIs, own free-tier subscriptions/logins,
+  # entirely independent of the Ollama cloud quota. Tried in this order per
+  # round; first one that returns a non-empty result wins. See
+  # .claude/skills/lib/agents.sh for the adapters. `agy` was evaluated and
+  # excluded: even given the full review prompt it consistently explores
+  # the filesystem instead of answering (verified 2026-07-29, not a
+  # prompt-wording issue).
+  external_agents:
+    - { tool: cursor-agent, model: auto }
+    - { tool: omp }
+    - { tool: codex }
+    - { tool: opencode, model: "opencode/nemotron-3-ultra-free" }
+    - { tool: kilo }
+
+  # Tier 3 — local failover, tools-capable models, no network dependency.
+  # Engages only if the Ollama cloud tier is unreachable AND every
+  # external_agents tool above also failed/returned empty.
   # ollama-review.sh reads the prompt from stdin, calls the OpenAI-compat
   # endpoint, and returns the model's raw content (JSON array expected).
   cli:
@@ -40,6 +55,14 @@ pricing:
   "qwen3.5:cloud":       { input: 0.00, output: 0.00 }
   "minimax-m2.7:cloud":  { input: 0.00, output: 0.00 }
   "gemma4:31b-cloud":    { input: 0.00, output: 0.00 }
+  # External-agent tools (reviewers.external_agents) — keyed by tool name,
+  # not model; telemetry's "model" field becomes the tool name on
+  # external_agents failover (see lib/agents.sh). Free (own subscriptions).
+  "cursor-agent": { input: 0.00, output: 0.00 }
+  "omp":          { input: 0.00, output: 0.00 }
+  "codex":        { input: 0.00, output: 0.00 }
+  "opencode":     { input: 0.00, output: 0.00 }
+  "kilo":         { input: 0.00, output: 0.00 }
   # Local failover models (reviewers.cli)
   "qwen3-coder:30b":  { input: 0.00, output: 0.00 }
   "qwen2.5-coder:7b": { input: 0.00, output: 0.00 }

--- a/.claude/skills/lib/agents.sh
+++ b/.claude/skills/lib/agents.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# lib/agents.sh — external coding-agent CLI adapters for /fix-review tier 2
+#
+# Usage:
+#   source .claude/skills/lib/agents.sh
+#
+#   OUT=$(run_external_agent "cursor-agent" "auto" "$PROMPT_FILE")
+#   try_external_agents 1 "$PROMPT_FILE" "$CONFIG"   # cascades the ordered
+#                                                     # reviewers.external_agents
+#                                                     # list from config.yaml
+#
+# Each of cursor-agent/omp/codex/opencode/kilo is invoked read-only
+# (no edits, no shell execution) and already unwraps its own tool-specific
+# output envelope, so callers get plain text back — the SAME code-fence-strip
+# + JSON-array-validate logic already used for Ollama responses (see
+# fix-review/SKILL.md STEP 4 parse_round()) works unchanged downstream.
+#
+# All prompt content is piped via stdin/file-ref, never a shell argument —
+# PR diffs can be large enough to risk ARG_MAX.
+#
+# `agy` was evaluated and dropped: even with the full review prompt (not
+# just a throwaway one-liner) it consistently explores the filesystem/
+# environment instead of answering directly, in both --mode plan and
+# unrestricted modes. Not a prompt-wording problem — verified 2026-07-29.
+
+# ---------------------------------------------------------------------------
+# Per-tool adapters — read-only invocation + envelope extraction, verified
+# against real calls with a realistic review prompt (not just --help docs).
+# ---------------------------------------------------------------------------
+
+agent_cursor_agent() {
+  local model="$1" prompt_file="$2"
+  cursor-agent --print --output-format json --mode plan \
+    ${model:+--model "$model"} < "$prompt_file" \
+    | jq -r '.result // empty'
+}
+
+agent_omp() {
+  local model="$1" prompt_file="$2"
+  # omp's own "@file" syntax for message content (not stdin).
+  omp -p --mode json --no-tools ${model:+--model "$model"} "@$prompt_file" \
+    | jq -rs '[.[] | select(.type=="message_update") | .assistantMessageEvent
+               | select(.type=="text_end") | .content] | last // empty'
+}
+
+agent_codex() {
+  local model="$1" prompt_file="$2"
+  # Plain-text output with a banner + echoed prompt around the answer;
+  # take the last line that looks like a JSON array (codex prints the
+  # final answer twice — once inline, once in a closing summary).
+  codex exec --sandbox read-only ${model:+-m "$model"} - < "$prompt_file" 2>/dev/null \
+    | awk '/^\[/' | tail -1
+}
+
+agent_opencode() {
+  local model="$1" prompt_file="$2"
+  # No default model on this install — always pass one explicitly or the
+  # call errors out (verified 2026-07-29). config.yaml must set a model
+  # for this tool.
+  opencode run --format json ${model:+--model "$model"} < "$prompt_file" \
+    | jq -rs '[.[] | select(.type=="text")] | last | .part.text // empty'
+}
+
+agent_kilo() {
+  local model="$1" prompt_file="$2"
+  # Same CLI/event shape as opencode (fork/whitelabel of the same project),
+  # but has a working default model — --model stays optional.
+  kilo run --format json ${model:+--model "$model"} < "$prompt_file" \
+    | jq -rs '[.[] | select(.type=="text")] | last | .part.text // empty'
+}
+
+# ---------------------------------------------------------------------------
+# Dispatcher + cascade
+# ---------------------------------------------------------------------------
+
+# Usage: run_external_agent "<tool>" "<model-or-empty>" "<prompt-file>"
+# Prints extracted text to stdout. Empty output == failure for this tool.
+run_external_agent() {
+  local tool="$1" model="$2" prompt_file="$3"
+  case "$tool" in
+    cursor-agent) agent_cursor_agent "$model" "$prompt_file" ;;
+    omp)          agent_omp          "$model" "$prompt_file" ;;
+    codex)        agent_codex        "$model" "$prompt_file" ;;
+    opencode)     agent_opencode     "$model" "$prompt_file" ;;
+    kilo)         agent_kilo         "$model" "$prompt_file" ;;
+    *)
+      echo "warn: unknown external agent tool '$tool' — skipping" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Usage: try_external_agents <round-n> <prompt-file> <config-path> <run-dir>
+# Walks reviewers.external_agents in config.yaml order; first tool that
+# returns non-empty output wins. Writes round_${n}.raw.json / .meta /
+# .failover on success (same marker-file convention SKILL.md STEP 3/11
+# already use for the ollama_local tier). Returns 1 if every tool failed
+# (or the config key is absent) so the caller falls through to ollama_local.
+try_external_agents() {
+  local n="$1" prompt_file="$2" config="$3" run_dir="$4"
+  local entry tool model out
+
+  # Read the config list on fd 3, not stdin — several adapters (cursor-agent,
+  # codex, opencode) read their prompt from stdin, and a `while read` loop
+  # driven by stdin would otherwise race/interleave with those inner reads
+  # (confirmed empirically: without this, a tool mid-loop got truncated
+  # input because it silently shared the loop's stdin stream).
+  while IFS= read -r entry <&3; do
+    [ -z "$entry" ] && continue
+    tool=$(jq -r '.tool' <<<"$entry")
+    model=$(jq -r '.model // empty' <<<"$entry")
+    echo "warn: round ${n} trying external agent ${tool}${model:+ ($model)}" >&2
+    out=$(run_external_agent "$tool" "$model" "$prompt_file" 2>/dev/null </dev/null)
+    if [ -n "$(printf '%s' "$out" | tr -d '[:space:]')" ]; then
+      printf '%s' "$out" > "$run_dir/round_${n}.raw.json"
+      printf '%s\n0' "$tool" > "$run_dir/round_${n}.meta"
+      printf 'external_agents:%s' "$tool" > "$run_dir/round_${n}.failover"
+      return 0
+    fi
+    echo "warn: round ${n} external agent ${tool} failed/empty — trying next" >&2
+  done 3< <(yq -c '.reviewers.external_agents[]' "$config" 2>/dev/null)
+
+  return 1
+}


### PR DESCRIPTION
## Summary
- `reviewers.cli` was named as if it were an external-tool tier but was actually just local Ollama in disguise — there was no real external-agent fallback between the cloud tier and going fully offline.
- Add `reviewers.external_agents` (cursor-agent, omp, codex, opencode, kilo) as a genuine tier 2, sourced from a new `.claude/skills/lib/agents.sh` (copied verbatim from the canonical `~/wrk/common/skills/lib/agents.sh`).
- `SKILL.md` Step 2's tier fallback is now `cloud → external_agents → cli` (was `cloud → cli`); Step 3 dispatches each round through the active tier via a new `dispatch_round` helper; Step 6's PR comment now names whichever tier actually produced each round's result.
- Pre-PR security review found two real issues (fixed in a follow-up commit): `dispatch_round` had no default case for an unrecognized `$TIER` (would silently degrade to "0 findings" instead of failing loudly), and the prompt/run temp files were never cleaned up. A third finding (opencode/kilo lack an explicit read-only/sandbox flag, unlike the other three tools) was verified empirically rather than fixed — a real prompt-injection payload against both tools (using the exact configured model) produced no destructive action; no stricter flag exists for either tool.
- The matching change in the backend repo (`vmm-rada`) is already open as PR #328 from a separate session — not duplicated here.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (123/123)
- [x] `bash -n .claude/skills/lib/agents.sh` — syntax valid
- [x] End-to-end tested with real tool calls (no PR was open to test the full `/fix-review` flow against, so ran the exact `dispatch_round` snippet standalone against a real merged diff): forced `TIER=external_agents`, confirmed the cascade tried cursor-agent (failed/empty) then fell through to omp (succeeded, valid JSON), and the failover marker correctly recorded `external_agents:omp`. Separately verified the all-external-agents-fail path correctly falls through to the `cli` tier.
- [x] Security-adversarial test: crafted a fake diff containing a prompt-injection payload instructing the reviewing agent to write a marker file and run a shell command. Ran it through both opencode and kilo with their actual configured models — neither executed anything; kilo refused outright, opencode correctly flagged it as a critical finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)