### PR TITLE
⚡ chore(fix-review): add agy to external_agents tier

### DIFF
--- a/.claude/skills/fix-review/config.yaml
+++ b/.claude/skills/fix-review/config.yaml
@@ -24,6 +24,7 @@ reviewers:
   # prompt-wording issue).
   external_agents:
     - { tool: cursor-agent, model: auto }
+    - { tool: agy, model: "Gemini 3.5 Flash (Low)" }
     - { tool: omp }
     - { tool: codex }
     - { tool: opencode, model: "opencode/nemotron-3-ultra-free" }
@@ -59,6 +60,7 @@ pricing:
   # not model; telemetry's "model" field becomes the tool name on
   # external_agents failover (see lib/agents.sh). Free (own subscriptions).
   "cursor-agent": { input: 0.00, output: 0.00 }
+  "agy":          { input: 0.00, output: 0.00 }
   "omp":          { input: 0.00, output: 0.00 }
   "codex":        { input: 0.00, output: 0.00 }
   "opencode":     { input: 0.00, output: 0.00 }

--- a/.claude/skills/lib/agents.sh
+++ b/.claude/skills/lib/agents.sh
@@ -35,6 +35,17 @@ agent_cursor_agent() {
     | jq -r '.result // empty'
 }
 
+agent_agy() {
+  local model="$1" prompt_file="$2"
+  # Unlike every other adapter here, the prompt MUST be a positional
+  # argument, not stdin/file-ref — verified 2026-07-30. --prompt is an
+  # alias for the --print boolean flag, not a value-taking option; the
+  # actual prompt text goes after -p as a trailing positional argument.
+  agy -p "$(cat "$prompt_file")" --model "${model:-Gemini 3.5 Flash (Low)}" \
+    --mode plan --output-format json 2>/dev/null \
+    | jq -r '.response // empty'
+}
+
 agent_omp() {
   local model="$1" prompt_file="$2"
   # omp's own "@file" syntax for message content (not stdin).
@@ -79,6 +90,7 @@ run_external_agent() {
   local tool="$1" model="$2" prompt_file="$3"
   case "$tool" in
     cursor-agent) agent_cursor_agent "$model" "$prompt_file" ;;
+    agy)          agent_agy          "$model" "$prompt_file" ;;
     omp)          agent_omp          "$model" "$prompt_file" ;;
     codex)        agent_codex        "$model" "$prompt_file" ;;
     opencode)     agent_opencode     "$model" "$prompt_file" ;;


### PR DESCRIPTION
## Summary
- The `external_agents` tier shipped in #112 was missing `agy`, using the same reasoning canonical originally had before the root cause was found.
- Root cause: `agy --prompt "text"` silently dropped the text (--prompt is an alias for the --print boolean flag), leaving agy with no real task and causing it to fall back to autonomous filesystem exploration. The fix is to pass the prompt as a bare positional argument after `-p`, NOT via stdin/file-ref or `--prompt`.
- Added an `agent_agy()` adapter using `agy -p "$(cat "$prompt_file")" --model ... --mode plan --output-format json` and reading `.response` from the JSON envelope.
- Registered `agy` in `run_external_agent()`'s dispatcher case.
- Added `agy` to `reviewers.external_agents` (second position, after `cursor-agent`) and to `pricing:` in `config.yaml`.

## Test plan
- [x] `bash -n .claude/skills/lib/agents.sh` — syntax valid
- [x] `yq -c '.reviewers.external_agents[]' .claude/skills/fix-review/config.yaml` — `agy` appears with model `Gemini 3.5 Flash (Low)`
- [x] `npm run lint` passes
- [x] `npm test` passes (123/123)
- [x] Pre-PR security check: ran the same adversarial prompt-injection payload used in #112 against agy via the real `try_external_agents` dispatcher path. agy correctly flagged the injection as a critical finding, did not create the marker file or run any shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)