### PR TITLE
⚡ chore(gitignore): exclude tmp/ from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ graphify-out/
 *.njsproj
 *.sln
 *.sw?
+tmp/


### PR DESCRIPTION
## Summary
- Add `tmp/` to `.gitignore`. `tmp/` is the standard scratch directory convention in this repo for local-only artifacts (session reports, ad-hoc investigation notes, draft files that don't belong in the repo or its design-note sibling directory).

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (123/123)
- [x] One-line `.gitignore` addition — no runtime verification needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)