### PR TITLE
⚡ chore(dreaming): apply 2026-W30 report findings

### DIFF
--- a/.claude/dreaming/reports/2026-W30.md
+++ b/.claude/dreaming/reports/2026-W30.md
@@ -26,14 +26,20 @@ PRs examined: 20 merged (12 authored, 8 Dependabot); review comments read on 10
 - Evidence: `f3c073a`, `c12d85a`, `2492b94`, `75be50b` installed `/housekeeping`, `/self-learn`, `/doubt-driven-development` and the `test-generator` agent. `f1936f6` (PR #60) patched `CLAUDE.md` only. `docs/development-workflow.md` §Skills (lines 19–86) still lists exactly five skills — `/backlog`, `/ship`, `/fix-review`, `/find-bugs`, `/improve` — and §Agents (87–162) omits `test-generator`.
 - Suggest: one `docs:` PR syncing `development-workflow.md` §Skills/§Agents + a `make` line in `CLAUDE.md`. This is `docs-maintainer`'s exact remit and it was not invoked on any of those five PRs.
 
+> [applied — verified 2026-07-31 via /apply-dreaming: CLAUDE.md's Commands section documents `make` targets; docs/development-workflow.md's §Skills/§Agents lists include all current skills/agents (test-generator, doubt-driven-development, housekeeping, self-learn). Resolved prior to this dreaming pass being actioned — exact commit not identified, no further action needed.]
+
 **Workflow gate — `/fix-review` before merge — skipped on 3 PRs.** Severity: medium. Confidence: `medium` (absence of a posted comment is strong but not conclusive evidence the pass never ran; `post_summary_to_pr: true` in `config.yaml:35` means a run should have posted).
 - Evidence: PRs #47, #54, #62 carry no `/fix-review` summary comment. #47 (`809d055`) is the **largest `src/` diff in the repo's history** — the whole monorepo→standalone frontend extraction — and is the one PR where the four Layer 1 rules actually had surface to be violated.
 - Suggest: no retroactive action; note as precedent. If `/ship` is the intended path, its gate is not enforced for manually-driven PRs.
+
+> [skipped 2026-07-31: report's own recommendation is no retroactive action]
 
 **Branch naming — one violation.** Severity: low. Confidence: `high`.
 - Evidence: `origin/fix-ollama-model-retirement` (PR #62) — missing the `fix/` prefix required by `CLAUDE.md` §Workflow and `docs/development-workflow.md:250-258`.
 - Related inconsistency: `CLAUDE.md` lists four branch prefixes (`feat/fix/docs/refactor`); `docs/development-workflow.md:257` also lists `chore/`, which is what 4 of the last 8 branches actually used. `627ede7` used commit type `task(config):`, absent from both docs' Conventional Commits lists.
 - Suggest: promote `chore/` into `CLAUDE.md`, or drop the branch table from `CLAUDE.md` and point at `development-workflow.md` as the single source.
+
+> [applied 2026-07-29: PR #108 (gh#79) — CLAUDE.md's branch/commit-type list replaced with a pointer to docs/development-workflow.md as the single source of truth, which already had the complete list including `chore/` and `task(scope):`.]
 
 ## 2. Recurring `/fix-review` themes
 
@@ -46,17 +52,24 @@ Tally across the 7 PRs with a posted summary (#53, #55, #56, #57, #58, #59, #63)
   - `doubt-driven-development/SKILL.md:45/68` — "future date 2026-07-07" (PR #59, 2/3 votes); it was 13 days past.
   - Suggest: prepend a short immutable **project-facts block** to the reviewer prompt (plain JS / no TS, Vitest present, Vite 8 + React 19, current date, `.claude/` files are instructions not runtime code). Cheapest lever available — it would have suppressed 6 of 14 dismissals without touching arbiter logic. Owner: `.claude/skills/fix-review/`.
 
+> [applied — verified 2026-07-31 via /apply-dreaming: present in .claude/skills/fix-review/SKILL.md Step 3's PROJECT_FACTS block, predating this dreaming pass being actioned. No further action needed.]
+
 - **"Reviewer treats `.claude/**/*.md` as production code"** — n≈8, i.e. effectively every finding in [#57, #58, #59]. Confidence: `high`.
   - Arbiter wrote the same sentence verbatim on five PRs: *"diff is …markdown only (no `src/` changes) — none of the four Layer 1 immutable rules apply."*
   - Suggest: a diff-shape pre-gate — if the diff touches no `src/`, run one reviewer instead of three. Three cloud models × zero yield is the current steady state.
+
+> [applied — verified 2026-07-31 via /apply-dreaming: present as SKILL.md Step 1.5 (REVIEWER_COUNT gate), predating this dreaming pass being actioned. No further action needed.]
 
 - **The single CONFIRMED finding was the one about `src/` semantics** — `.claude/agents/test-generator.md:41` (PR #56, 1/3 votes): XSS regression guidance asserted via raw `container.innerHTML` string match; changed to `querySelector('script') === null`, fixed in `4a02051`. Confidence: `high`.
   - Suggest: worth a line in `context-essentials.md` §Banned patterns — *"XSS assertions go through `querySelector`, never `innerHTML` string matching"* — since rule 4 is the rule most likely to be regression-tested wrongly. This is the only genuinely durable lesson the whole review corpus produced.
 
 > [planned 2026-07-26: issue #71 (task(dx): add XSS assertion rule to context-essentials banned patterns); awaiting /backlog → Tech Lead → /ship]
+> [applied 2026-07-27 (PR #93): rule landed in context-essentials.md §Banned patterns — "No XSS-safety assertions via raw `innerHTML` string matching — use `container.querySelector('script') === null` instead." Follow-up note added 2026-07-31 via /apply-dreaming.]
 
 - **`gh pr diff` returned an `rtk`-compacted summary instead of a real diff** (PR #58 arbiter note, worked around via `git diff main...<branch>`). n=1, but it silently degrades review input. Confidence: `medium`.
   - Suggest: make `git diff main...HEAD` the primary source in the skill, not the fallback.
+
+> [applied 2026-07-28: PR #107 (gh#80) — .claude/skills/fix-review/SKILL.md Step 1 now fetches via `git fetch origin pull/$PR/head:pr-$PR && git diff main...pr-$PR` as primary, `gh pr diff` as fallback, plus a <50-line sanity re-fetch check.]
 
 ## 3. Stale plans
 
@@ -75,13 +88,19 @@ Tally across the 7 PRs with a posted summary (#53, #55, #56, #57, #58, #59, #63)
 - **`/doubt-driven-development` — installed, documented, wired into nothing.** Confidence: `high`. Grep for it in `ship/SKILL.md`, `backlog/SKILL.md`, `context-essentials.md`, `docs/development-workflow.md`: zero hits. It appears only in `CLAUDE.md`'s skill list and in `session-log.md` as an install task. Its whole value is being invoked *in-flight*; nothing invokes it. Suggest: add it to the `context-essentials.md` workflow gate line, or accept it as opt-in-by-memory and say so.
 
 > [planned 2026-07-26: issue #72 (task(dx): wire /doubt-driven-development into the workflow gate); awaiting /backlog → Tech Lead → /ship]
+> [applied 2026-07-28 (PR #104): wired into context-essentials.md's Workflow gates section and docs/development-workflow.md's Feature implementation pipeline diagram. Follow-up note added 2026-07-31 via /apply-dreaming.]
 - **`/housekeeping` was installed 2026-07-20 and appears never to have been run** — its check #1 is stale branches, and 7 merged remote branches plus 2 local ones are still sitting there (below). Confidence: `medium`.
 - **`/find-bugs` and `/improve`: no usage evidence** in `session-log.md` or any PR comment. Both predate the current tooling wave. Not obsolete — but `/find-bugs` (5-phase audit of branch changes) overlaps the `security-reviewer` agent and `/fix-review`'s Layer 2 pass substantially. Suggest: pick one entry point for pre-PR bug hunting; three is why none gets used.
 - **`tech-lead.md:149` cites a `/plan` skill that does not exist** — the pipeline line reads `/plan skill → Tech Lead (YOU) → …`; the actual skill is `/backlog`. Severity: low, but it's the architectural authority's own pipeline diagram. Confidence: `high`.
 
 > [planned 2026-07-26: issue #74 (task(dx): fix /plan typo in tech-lead.md pipeline diagram); awaiting /backlog → Tech Lead → /ship]
+> [applied 2026-07-28 (PR #102): tech-lead.md's pipeline line now reads `/backlog skill → Tech Lead (YOU) → ...`. Follow-up note added 2026-07-31 via /apply-dreaming.]
 - **Agent overlap:** `code-simplifier` (project) vs. the global `/simplify` skill; `security-reviewer` (project agent) vs. `/find-bugs` (project skill) vs. the global `/security-review`. No conflict observed in practice, mostly because none of them ran this period.
+
+> [manual-review-required 2026-07-31: this is a judgment call (which of 3 overlapping bug-hunting entry points to keep) with no single correct answer — not auto-applied. Same applies to the sibling `/find-bugs`-vs-`/improve` overlap noted in §5. Flagged to the user, not decided here.]
 - **Stale branches** (`git branch -a`): `origin/chore/add-makefile`, `origin/chore/doubt-driven-development-skill`, `origin/chore/housekeeping-skill`, `origin/chore/self-learn-skill`, `origin/docs/doubt-driven-development-sandbox-checklist`, `origin/docs/skills-list-gaps`, `origin/fix-ollama-model-retirement` — all merged, none deleted. Plus local `feat/sync-frontend-from-vmm-rada-monorepo` (2026-07-19) and `fix-ollama-model-retirement` (2026-07-22). Suggest: enable auto-delete-branch-on-merge in repo settings; it makes `/housekeeping` check #1 permanently green instead of permanently ignored.
+
+> [applied 2026-07-31 via /apply-dreaming: verified via `gh api repos/.../branches` that GitHub itself has zero non-main branches — every branch named above was already deleted (subsequent PR merges this session all used `--delete-branch`). Local stale remote-tracking refs pruned via `git remote prune origin`. `delete_branch_on_merge` repo setting enabled (was `false`) so this is automatic going forward regardless of merge-flag discipline. Three local-only branches with unmerged commits (`chore/dreaming-ollama`, `feat/sync-frontend-from-vmm-rada-monorepo`, `fix-ollama-model-retirement`) were found and deliberately left alone — not part of this finding's evidence, and deleting unmerged work needs explicit confirmation, not an assumption.]
 - **Model config is consistent** — `fix-review/config.yaml:14-16` (`qwen3.5:cloud`, `minimax-m2.7:cloud`, `gemma4:31b-cloud`) and `session-end.sh:165-170` (`glm-5.2`, `kimi-k2.6`, `minimax-m2.7`, `qwen3.5`) both post-date the 2026-07-31 Ollama retirement of `minimax-m2.5`/`kimi-k2.5` (PR #62, mirrored backend-side in `vmm-rada@96f6af7`). No action.
 
 ## 6. Backend contract drift
@@ -94,20 +113,31 @@ Frontend `docs/api-contract.md` and `docs/streaming.md` were both last touched `
   - Suggest: file it. Surface 409 as a distinct, actionable state in `App.jsx`'s `error` field, and document the code in `docs/api-contract.md`.
 
 > [planned 2026-07-26: issue #70 (bug/api/ui: handle 409 ErrConversationClosed on clarification endpoints); awaiting /backlog → Tech Lead → /ship]
+> [applied 2026-07-28 (PR #101, gh#95 + PR #105, gh#100): 409 causes discriminated by message string via a Map (`KNOWN_ERROR_CODES`) in src/api.js; App.jsx's non-closed-409 catch path now actually restores `pendingClarification`. Follow-up note added 2026-07-31 via /apply-dreaming.]
 - **`RoleBased` is now a live strategy; the frontend renders a stub.** Severity: medium. Confidence: `high`.
   - Evidence: `vmm-rada@e066bc8` (2026-07-21, PR #303) registers `role-based` with `ROLE_BASED_MODELS` / `ROLE_BASED_CHAIRMAN_MODEL`, fixed `DefaultRoles` (Generator/Critic/Verifier/Simplifier), `QuorumMin = len(DefaultRoles)`. Previously unreachable in production.
   - Frontend: `docs/streaming.md:197` maps `role_stub` → `[]` data, and `src/components/Stage2.jsx:631` is `RoleStubView`, "a minimal placeholder." The docs are *accurate*, but the strategy went from unreachable to deployable and Stage 2 shows a placeholder if anyone sets `DEFAULT_RADA_TYPE=role-based`.
   - Suggest: confirm whether the backend now emits richer role payload; if so, `RoleStubView` needs a real view. At minimum, mark it `NOT YET WIRED:` per the docs-discipline rule.
+
+> [applied 2026-07-27 (PR #88): implemented a real RoleView for the RoleBased strategy, replacing the placeholder stub. Follow-up note added 2026-07-31 via /apply-dreaming.]
 - **Golden-file contract tests + `docs/api.md` corrections** — `vmm-rada@18ef804` (PR #309) and `cd5fb5e` (per-endpoint error-reference column, PR #311). Confidence: `medium` on impact; I did not diff the backend's `docs/api.md` against this repo's `docs/api-contract.md` field by field.
   - Suggest: a `docs-maintainer` pass diffing the two, now that the backend has golden files to diff *against*. The backend's new golden fixtures are the closest thing to a machine-checkable contract this pair has ever had — worth considering as a CI input here.
+
+> [applied 2026-07-29/31: a direct investigation of vmm-rada's commit history (not docs-maintainer — that agent's tools frontmatter turned out to be broken, see project memory) produced issues #110 (stale CLAUDE.md/user-guide.md env-var docs, PR #115) and #111 (api-contract.md error-reference granularity + a real inaccuracy re: 503 never being a real streaming-endpoint status, PR #116). Both shipped.]
 - Context: `vmm-rada@48ae260` (2026-07-20) removed the deprecated `frontend/` from the monorepo. The split is complete; from here the two repos drift unless something checks. Nothing checks.
 
 ## 7. Patterns I noticed
 
 - **The tooling has outgrown the product.** 11 skills, 10 agents, 4 hooks, dreaming, session-recall, self-learn, CI, a Makefile — and 9 lifetime commits to `src/`, the last of which was a file move. Every one of the 12 authored PRs since 2026-07-19 is `chore(dx)`, `docs`, or `task(config)`. The four Layer 1 immutable rules are perfectly observed, largely because almost no code has been written since they were written.
 - **Zero open GitHub issues.** Issues #48–#52 all closed 2026-07-20; nothing filed since. `CLAUDE.md` §Known gaps documents the strategy picker — `src/App.jsx:300` hardcodes `council_type: 'default'`, and `deriveStage2Kind` + the seven-way `Stage2.jsx` dispatcher are already built to receive it. It has never been an issue. It's the highest-value, lowest-risk product work available and the backlog is otherwise empty.
+
+> [planned 2026-07-31: .claude/plans/2-dreaming-w30-strategy-picker.md; awaiting /backlog → Tech Lead → /ship]
 - **Test coverage is concentrated where the risk isn't.** 38 tests across `App.test.jsx`, `api.test.js`, `Stage2.test.jsx`. No tests for `Stage0`, `Stage1`, `Stage3`, `Sidebar`, `ChatInterface`, `Markdown`, `EmptyState`, or `utils.js`. `Markdown.jsx` is the enforcement point for immutable rule 4 and has no test asserting that raw HTML doesn't render — the exact gap PR #56's confirmed finding was about. `test-generator` was built for this and has not been invoked once since.
+
+> [applied 2026-07-27 (PR #93): verified 2026-07-31 via /apply-dreaming — every named file now has a co-located test (Stage0.test.jsx, Stage1.test.jsx, Stage3.test.jsx, Sidebar.test.jsx, ChatInterface.test.jsx, Markdown.test.jsx, EmptyState.test.jsx, utils.test.js all present).]
 - **CI pins `node-version: '20'`** (`.github/workflows/ci.yml:20`) against `engines: >=20.19.0`. Functional today, but Node 20 is past EOL and the backend already bumped `actions/setup-node` to v7 (`vmm-rada@28d18bf`). Low severity, cheap to bump to 22.
+
+> [applied — verified 2026-07-31 via /apply-dreaming: .github/workflows/ci.yml now pins `node-version: '22'`; package.json engines.node and .npmrc's `engine-strict=true` (gh#86) match. No further action needed.]
 - **`/apply-dreaming` has existed with nothing to apply.** `.claude/dreaming/reports/` was empty before this run — `.dreaming.log` starts `2026-07-26T09:26:17`. This is the first report; the loop has never closed once.
 
 ## 8. What I couldn't tell (need manual review)
@@ -117,3 +147,7 @@ Frontend `docs/api-contract.md` and `docs/streaming.md` were both last touched `
 - **Whether `RoleBased`'s SSE payload changed shape** in `vmm-rada@e066bc8`. I read the commit message and diffstat, not the strategy's emit path. If `data` is still `[]`, `docs/streaming.md:197` remains correct and only the view is thin.
 - **Field-level parity between backend `docs/api.md` and frontend `docs/api-contract.md`** after PRs #309/#311. Needs a real side-by-side.
 - **Whether `/find-bugs` and `/improve` are deliberately-held tools or dead weight.** No usage signal either way in the transcripts I can see from here; `/recall` over older sessions would answer it.
+
+> [manual-review-required 2026-07-31: still genuinely unknown — same open question as §5's agent-overlap note. Not resolved by this pass.]
+
+> [Section 8, remaining items — resolved via subsequent work, verified 2026-07-31 via /apply-dreaming: (a) fix-review's signal-to-noise was fixed by the project-facts block + diff-shape gate, both applied; (b) the 409 gap is now fully handled (gh#95, gh#100) with regression tests, reachability is moot; (c) RoleBased's SSE payload was confirmed to warrant a real view — PR #88 shipped one; (d) api.md/api-contract.md field-level parity was done directly — issues #110/#111, PR #115/#116.]

--- a/.claude/plans/2-dreaming-w30-strategy-picker.md
+++ b/.claude/plans/2-dreaming-w30-strategy-picker.md
@@ -44,6 +44,10 @@ available" given the backlog was otherwise empty.
       (`msg.error`), not a silent failure.
 - [ ] `CLAUDE.md`'s "Known gaps" entry for the strategy picker is removed
       once this ships.
+- [ ] The picker sends a value from the fixed enum of 7 known
+      `council_type` strings — never free text — to avoid arbitrary
+      `council_type` injection (flagged by security-reviewer during this
+      plan's pre-PR review).
 
 ## Implementation
 

--- a/.claude/plans/2-dreaming-w30-strategy-picker.md
+++ b/.claude/plans/2-dreaming-w30-strategy-picker.md
@@ -1,0 +1,137 @@
+---
+title: "Add a strategy picker to the UI"
+type: feature
+priority: p2-medium
+status: draft
+debt: balanced
+effort: m
+component:
+  - ui
+  - stage2
+  - config
+labels:
+  - enhancement
+  - p2-medium
+  - ux
+blocked_by: null
+github_issue: null
+created: 2026-07-31
+updated: 2026-07-31
+---
+
+## Summary
+
+`handleSendMessage` in `src/App.jsx:324` hardcodes `council_type: 'default'`
+on every request. All 7 backend deliberation strategies are already fully
+supported end-to-end — `deriveStage2Kind` and the `Stage2.jsx` dispatcher
+handle every `kind` value, `docs/streaming.md` documents all 7 payload
+shapes — but there is no UI affordance to choose anything but the default.
+This has been a documented gap in `CLAUDE.md`'s "Known gaps" section since
+before this plan existed; the 2026-W30 dreaming report (§7, "Patterns I
+noticed") flagged it as "the highest-value, lowest-risk product work
+available" given the backlog was otherwise empty.
+
+## Acceptance Criteria
+
+- [ ] A strategy picker UI element lets the user choose a `council_type`
+      before sending a message (or per-conversation — see Approach).
+- [ ] `handleSendMessage` sends the selected `council_type` instead of the
+      hardcoded `'default'` literal.
+- [ ] The default selection remains `'default'` — no behavior change for
+      users who don't interact with the picker.
+- [ ] If the backend rejects an unregistered `council_type` (see Risks),
+      the resulting error surfaces through the existing error-handling path
+      (`msg.error`), not a silent failure.
+- [ ] `CLAUDE.md`'s "Known gaps" entry for the strategy picker is removed
+      once this ships.
+
+## Implementation
+
+### Files to change
+
+- `src/App.jsx` — `handleSendMessage` needs a `council_type` value to send;
+  state for the current selection must live here per the immutable
+  App.jsx-owns-all-state rule.
+- `src/components/ChatInterface.jsx` or `src/components/Sidebar.jsx` — the
+  picker UI itself (pure UI, no `api.js` calls — passes the selection up via
+  a prop/callback into `App.jsx`, same pattern as existing user-input
+  handlers).
+- `CLAUDE.md` — remove the "Known gaps" bullet once shipped.
+
+### Files to read (context only)
+
+- `src/components/Stage2.jsx` — confirms the dispatcher already handles all
+  7 `kind` values; no changes needed here.
+- `docs/api-contract.md:143-156` — the `council_type` request field is
+  already documented; note whether its description needs updating once a
+  picker exists (currently says "defaults to the backend's
+  `DEFAULT_RADA_TYPE` env var" when omitted — still true, the picker would
+  just stop omitting it).
+
+### Approach
+
+Two open design questions with real trade-offs — resolve before implementing,
+not during:
+
+1. **Where does the picker live?** Options: (a) a dropdown in the chat input
+   area, selected per-message; (b) a per-conversation setting chosen once
+   when a conversation starts, immutable after the first message (mirrors
+   how `council_type` actually behaves server-side — it's read once per
+   request, but changing strategy mid-conversation on already-persisted
+   messages would produce a conversation with mixed `stage2Kind` values,
+   which the frontend already handles via replay's shape-based
+   `deriveStage2Kind`, but may be a confusing UX).
+2. **What's the source of truth for the available strategy list?** The
+   backend has no "list registered council types" endpoint (verified: not
+   in `docs/api-contract.md`'s Endpoints section). Options: (a) hardcode the
+   known 7 wire values (`default`, `role-based`, `majority`,
+   `generate-rank-refine`, `debate`, `moa`, `delphi` — these are stable,
+   documented in the backend's `configs/council.yaml` header comment as
+   wire-compatible identifiers that won't change), accepting that a given
+   backend deployment may not have all 7 registered (request fails at
+   send-time with a normal error, same as any other invalid input); (b) file
+   a backend issue requesting a discovery endpoint first, blocking this plan
+   on that. Given the backend explicitly commits to the 7 names staying
+   stable, (a) is very likely the right call for a first version — no backend
+   change required, ships faster, and the failure mode (a strategy not
+   registered on this deployment) is no worse than any other 400/503 the
+   app already surfaces.
+
+### Risks / Unknowns
+
+- **Very likely fine:** the 7 wire values are stable per the backend's own
+  `configs/council.yaml` header comment (a repo the current investigation
+  already read directly) — hardcoding them client-side is low risk.
+- **Likely needs a decision, not a default:** per-message vs.
+  per-conversation strategy selection (open question 1 above) — surface
+  this to the user/reviewer rather than picking silently.
+- **Unlikely but possible:** a backend deployment has fewer than 7 strategies
+  registered (e.g. `configs/council.yaml` omits one, or the legacy env-var
+  path is in use with only some `*_MODELS` vars set) — the picker would
+  offer a strategy that 503s or 500s at send time. Acceptable for v1; a
+  future backend discovery endpoint would close this gap.
+
+## Not in Scope
+
+- A backend endpoint to list registered strategies (see Risks) — this plan
+  assumes the hardcoded 7-value list.
+- Per-strategy configuration UI (model rosters, temperature, etc.) — only
+  strategy *selection*, not strategy *configuration*.
+- Changing the default strategy or any existing strategy's behavior.
+
+## Commit Message
+
+```
+feat(app): add strategy picker to chat UI ⚖️
+```
+
+## After Implementing
+
+- [ ] `npm run lint` passes
+- [ ] `npm test` passes
+- [ ] Manual smoke test with backend running: send a message with each of
+      the 7 strategies, confirm Stage2.jsx renders the correct view for
+      each
+- [ ] `/ship` to create PR and merge
+- [ ] Remove the "Known gaps" bullet in `CLAUDE.md`
+- [ ] Move plan status to `done`, fill `github_issue` if created


### PR DESCRIPTION
## Summary
- First `/apply-dreaming` pass against the 2026-W30 report (generated 2026-07-26, never actioned).
- Cross-checked every finding against current repo state rather than trusting the report at face value.
- **12 of ~15 actionable findings already resolved** — most shipped during this session without going through `/apply-dreaming` formally. Annotated each with the PR that fixed it (branch-naming, git-diff-primary, doubt-driven-development wiring, tech-lead.md typo, 409 handling, RoleBased view, backend docs reconciliation, test coverage gaps, CI Node version).
- **Stale branches**: verified via `gh api repos/.../branches` that GitHub has zero non-main branches. Pruned local stale remote-tracking refs. Enabled `delete_branch_on_merge` as a repo setting.
- **One genuine gap remains**: no strategy picker in the UI, despite all 7 backend strategies already fully wired end-to-end. Drafted `.claude/plans/2-dreaming-w30-strategy-picker.md` for `/backlog` to pick up next.
- **Two items left as manual-review**, not auto-decided: the `/find-bugs` vs `/improve` vs `security-reviewer` overlap, and whether those two skills are deliberately held or dead weight.
- Three local-only branches with unmerged commits were found and deliberately left alone (unfamiliar in-progress work, not part of this report's evidence).
- Follow-up commit adds a fixed-enum acceptance criterion to the plan per security-reviewer's pre-PR note (the future picker must send a value from the 7 known `council_type` strings, never free text).

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (123/123)
- [x] Docs/plan-only change — no runtime verification needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)