### PR TITLE
⚡ chore(agents): flag new CLI-deps in lib/ lacking SKILL.md docs

### DIFF
--- a/.claude/agents/code-simplifier.md
+++ b/.claude/agents/code-simplifier.md
@@ -66,6 +66,13 @@ Apply when appropriate:
 - Cryptic single-letter names → descriptive names
 - Only rename when clearly better and unambiguous
 
+## Documentation Parity Checks
+
+- If a change adds a CLI invocation (e.g. `yq`, `jq`, `fzf`, `curl`) or
+  version-pins an existing one under `.claude/skills/lib/` or any shared
+  bash helper, verify the consuming `SKILL.md` prerequisites block lists
+  the dependency. Flag if missing.
+
 ## Safety Rules — When NOT to Simplify
 
 Do not simplify:


### PR DESCRIPTION
## Summary
- Adds a `## Documentation Parity Checks` sub-section to `.claude/agents/code-simplifier.md`, between the existing `## Transformation Playbook` and `## Safety Rules — When NOT to Simplify` sections.
- The new guardrail: if a change adds a CLI invocation (e.g. `yq`, `jq`, `fzf`, `curl`) or version-pins an existing one under `.claude/skills/lib/` or any shared bash helper, verify the consuming `SKILL.md` prerequisites block lists the dependency, and flag if missing.
- Source: 2026-W31 dreaming report §2 flagged this as a recurring theme — `yq` was added to `lib/agents.sh` in PR #112 without a matching prerequisites update, caught post-PR by `/fix-review` instead of pre-PR.
- Tech Lead verdict (manual review, agent unavailable): `code-simplifier` chosen over `static-analysis` — the latter is scoped to ESLint cosmetic fixes with explicit `DO_NOT_TOUCH` zones, and this check is semantic, out of that agent's mandate.

Closes #122

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (123/123)
- [x] Markdown-only change — no dev server / runtime impact
- [x] Pre-PR security-reviewer: 0 findings (advisory-only, no new tool grants, no execution path)
- [x] Pre-PR static-analysis: 0 violations (no JS/JSX touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)