### PR TITLE
⚖️ feat(app): add strategy picker to chat UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,13 +130,6 @@ scheduled self-review (drift from `context-essentials.md`, recurring
 the systemd timer setup. Reports land in `.claude/dreaming/reports/`,
 applied via `/apply-dreaming`.
 
-## Known gaps
-
-- **No strategy picker in the UI.** `handleSendMessage` hardcodes
-  `council_type: "default"`. All seven strategies are already supported by
-  the Stage 2 dispatcher and the message state shape — only the
-  request-composition and any strategy-selection UI are missing.
-
 ## graphify
 
 This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -81,6 +81,20 @@ function mergeRoundIntoMessage(msg, event) {
   msg.stage2Kind = normaliseStage2Kind(event.kind);
 }
 
+// The 7 backend deliberation strategies, as documented in
+// docs/streaming.md's kind table. Wire values are stable per the backend's
+// configs/council.yaml header comment — hardcoded here rather than fetched
+// from a discovery endpoint (the backend has none; see gh#124).
+const COUNCIL_TYPES = [
+  { value: 'default', label: 'Default' },
+  { value: 'role-based', label: 'Role-Based' },
+  { value: 'majority', label: 'Majority Vote' },
+  { value: 'generate-rank-refine', label: 'Generate → Rank → Refine' },
+  { value: 'debate', label: 'Multi-Agent Debate' },
+  { value: 'moa', label: 'Mixture of Agents' },
+  { value: 'delphi', label: 'Delphi Panel' },
+];
+
 function App() {
   const [conversations, setConversations] = useState([]);
   const [currentConversationId, setCurrentConversationId] = useState(null);
@@ -88,6 +102,7 @@ function App() {
   const [isLoading, setIsLoading] = useState(false);
   const [theme, setTheme] = useState(() => localStorage.getItem('theme') ?? 'dark');
   const [sidebarOpen, setSidebarOpen] = useState(() => window.innerWidth >= 768);
+  const [councilType, setCouncilType] = useState('default');
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
@@ -175,6 +190,13 @@ function App() {
     if (currentConversationId) {
       loadConversation(currentConversationId);
     }
+  }, [currentConversationId]);
+
+  // Reset the strategy picker to the default on conversation switch — a
+  // selection made for one conversation should not silently carry over to
+  // the next. Persists across messages within the same conversation.
+  useEffect(() => {
+    setCouncilType('default');
   }, [currentConversationId]);
 
   const handleNewConversation = async () => {
@@ -321,7 +343,7 @@ function App() {
       const handlers = makeStreamHandlers(updateLast);
       await api.sendMessageStream(
         currentConversationId,
-        { content, council_type: 'default' },
+        { content, council_type: councilType },
         (eventType, event) => handlers[eventType]?.(event)
       );
     } catch (error) {
@@ -452,6 +474,9 @@ function App() {
         isLoading={isLoading}
         sidebarOpen={sidebarOpen}
         onToggleSidebar={toggleSidebar}
+        councilTypes={COUNCIL_TYPES}
+        selectedCouncilType={councilType}
+        onCouncilTypeChange={setCouncilType}
       />
     </div>
   );

--- a/src/components/ChatInterface.css
+++ b/src/components/ChatInterface.css
@@ -213,6 +213,38 @@
   cursor: not-allowed;
 }
 
+.strategy-picker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.strategy-picker-label {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.strategy-picker-select {
+  padding: 4px 10px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.strategy-picker-select:focus {
+  border-color: var(--border-focus);
+  outline: none;
+}
+
+.strategy-picker-select:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .input-row {
   display: flex;
   align-items: flex-end;

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -17,6 +17,9 @@ export default function ChatInterface({
   isConversationClosed,
   sidebarOpen,
   onToggleSidebar,
+  councilTypes,
+  selectedCouncilType,
+  onCouncilTypeChange,
 }) {
   const [input, setInput] = useState('');
   const [context, setContext] = useState('');
@@ -186,6 +189,24 @@ export default function ChatInterface({
             />
           )}
         </div>
+
+        <div className="strategy-picker">
+          <label htmlFor="council-type-select" className="strategy-picker-label">
+            Strategy
+          </label>
+          <select
+            id="council-type-select"
+            className="strategy-picker-select"
+            value={selectedCouncilType}
+            onChange={(e) => onCouncilTypeChange(e.target.value)}
+            disabled={isConversationClosed || isLoading || !!conversation.messages.at(-1)?.pendingClarification}
+          >
+            {councilTypes.map((ct) => (
+              <option key={ct.value} value={ct.value}>{ct.label}</option>
+            ))}
+          </select>
+        </div>
+
         <div className="input-row">
           <textarea
             ref={textareaRef}

--- a/src/components/ChatInterface.test.jsx
+++ b/src/components/ChatInterface.test.jsx
@@ -17,6 +17,12 @@ function baseProps(overrides = {}) {
     isConversationClosed: false,
     sidebarOpen: true,
     onToggleSidebar: vi.fn(),
+    councilTypes: [
+      { value: 'default', label: 'Default' },
+      { value: 'role-based', label: 'Role-Based' },
+    ],
+    selectedCouncilType: 'default',
+    onCouncilTypeChange: vi.fn(),
     ...overrides,
   };
 }
@@ -192,6 +198,40 @@ describe('ChatInterface', () => {
     ).toBeInTheDocument();
     // Stage0 itself renders the question text and its own submit/skip controls.
     expect(screen.getByText('Which framework?')).toBeInTheDocument();
+  });
+
+  it('renders the strategy picker with the provided options and reflects the selected value', () => {
+    render(
+      <ChatInterface
+        {...baseProps({ conversation: makeConversation(), selectedCouncilType: 'role-based' })}
+      />,
+    );
+    const select = screen.getByLabelText('Strategy');
+    expect(select).toHaveValue('role-based');
+    expect(screen.getByRole('option', { name: 'Default' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Role-Based' })).toBeInTheDocument();
+  });
+
+  it('calls onCouncilTypeChange when the strategy picker selection changes', async () => {
+    const onCouncilTypeChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ChatInterface
+        {...baseProps({ conversation: makeConversation(), onCouncilTypeChange })}
+      />,
+    );
+
+    await user.selectOptions(screen.getByLabelText('Strategy'), 'role-based');
+    expect(onCouncilTypeChange).toHaveBeenCalledWith('role-based');
+  });
+
+  it('disables the strategy picker when isConversationClosed', () => {
+    render(
+      <ChatInterface
+        {...baseProps({ conversation: makeConversation(), isConversationClosed: true })}
+      />,
+    );
+    expect(screen.getByLabelText('Strategy')).toBeDisabled();
   });
 
   it('shows the sidebar-open button only when the sidebar is closed', () => {


### PR DESCRIPTION
## Summary
- Adds a strategy picker `<select>` to the chat input area (between the context-toggle and the message input row), letting the user choose one of the 7 backend deliberation strategies instead of the hardcoded `council_type: 'default'`.
- Picker state lives in `App.jsx` (`councilType` useState) per the immutable "App.jsx owns all state" rule — `ChatInterface` remains pure UI, receiving `councilTypes`/`selectedCouncilType`/`onCouncilTypeChange` as props.
- Picker resets to `'default'` whenever `currentConversationId` changes; persists across messages within the same conversation (Stage 0 clarification round-trips don't reset it).
- Source of truth is a hardcoded array of the 7 stable wire values (`default`, `role-based`, `majority`, `generate-rank-refine`, `debate`, `moa`, `delphi`) — no backend discovery endpoint needed for v1, per the issue's design decision.
- The `<select>` is a closed enum (native browser semantics — no free text, no editable combobox), satisfying the security-reviewer's original design note against arbitrary `council_type` injection.
- Removes the now-resolved "No strategy picker in the UI" entry from `CLAUDE.md`'s Known gaps section.
- Added 3 new Vitest cases covering the picker's rendering, `onChange` wiring, and disabled state; updated the existing `baseProps()` test helper with the new required props (fixed 11 pre-existing tests that would otherwise crash on the new props being undefined).

Closes #124

## Test plan
- [x] `npm run lint` passes (0 issues)
- [x] `npm test` passes (126/126 — 123 existing + 3 new)
- [x] Pre-PR security-reviewer: 0 findings. Verified end-to-end that `council_type` is provably constrained to the 7 hardcoded values at every step (no free-text path exists), and no XSS risk from the `label` strings (rendered as plain JSX children, not innerHTML).
- [x] Pre-PR static-analysis: 0 violations, confirmed no DO_NOT_TOUCH zone touched (`src/api.js` untouched, no `onEvent`/`loading.stage*`/`isMounted`/`msg.error` changes).
- [ ] Manual smoke test: backend running locally, send one message with each of the 7 strategies, confirm `Stage2.jsx` renders the correct view for each — not yet run in this environment (no local backend instance); flagging for follow-up manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)